### PR TITLE
fixed the title of the fleet overview page

### DIFF
--- a/resources/views/fleet/index.blade.php
+++ b/resources/views/fleet/index.blade.php
@@ -1,5 +1,5 @@
 @extends('layouts.app')
-@section('title', 'YAAMS: Pilot Dashboard')
+@section('title', 'YAAMS: Fleet overview')
 @section('content')
 
         <script>


### PR DESCRIPTION
Just a little fix in the title of the Fleet overview page. 