### PR TITLE
Relationship error between Flight->Aircraft now fixed

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\Models\Aircraft;
+use App\Models\Flight;
 
 class DashboardController extends Controller
 {
@@ -13,6 +15,8 @@ class DashboardController extends Controller
     }
 
     public function index(){
-        return view('dashboard.index');
+        $currentActiveAirline = Session()->get('activeairline');
+        $airlineFlights = $currentActiveAirline->flights;
+        return view('dashboard.index', ['flights' => $airlineFlights]);
     }
 }

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -5,6 +5,8 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use App\Models\Aircraft;
 use App\Models\Flight;
+use App\Models\Airline;
+
 
 class DashboardController extends Controller
 {
@@ -16,7 +18,16 @@ class DashboardController extends Controller
 
     public function index(){
         $currentActiveAirline = Session()->get('activeairline');
-        $airlineFlights = $currentActiveAirline->flights;
+ 
+        // Alternative approach:
+        // $airlineFlights = $currentActiveAirline->flights;
+
+        $airlineFlights = Flight::query()
+        ->orderBy('created_at', 'DESC')
+        ->where('airline_id', '=', $currentActiveAirline->id )
+        ->limit(5)
+        ->get();
+
         return view('dashboard.index', ['flights' => $airlineFlights]);
     }
 }

--- a/app/Http/Controllers/FlightController.php
+++ b/app/Http/Controllers/FlightController.php
@@ -63,15 +63,10 @@ class FlightController extends Controller
 
         //TODO: Only get aircraft from an airline, which the pilot is member of
 
-        $prefill_select_aircraft = Aircraft::where('active', '=', true)
-        ->where('used_by', '=', $currentActiveAirline->id)
-        ->get();
-
-        //dump($prefill_select_aircraft);
+        $prefill_select_aircraft = $currentActiveAirline->aircraft;
 
         return view('flights.add', [ 'prefill_online_network' => $prefill_select_online_network,
                                      'prefill_aircraft' => $prefill_select_aircraft ]);
-
     }
 
     public function view(Flight $flight) {

--- a/app/Http/Controllers/FlightController.php
+++ b/app/Http/Controllers/FlightController.php
@@ -28,8 +28,8 @@ class FlightController extends Controller
         $currentActiveAirline = Session()->get('activeairline');
         
         $flights = Flight::query()
-        ->where('pilot', $current_auth_user_id)
-        ->where('airline', $currentActiveAirline->id)
+        ->where('pilot_id', $current_auth_user_id)
+        ->where('airline_id', $currentActiveAirline->id)
         ->orderBy('created_at', 'DESC')
         ->get();
 

--- a/app/Models/Aircraft.php
+++ b/app/Models/Aircraft.php
@@ -45,11 +45,11 @@ class Aircraft extends Model
     }
 
     public function getTotalFlightsCountAttribute() {
-        return Flight::where('aircraft', '=', $this->id)->count();
+        return Flight::where('aircraft_id', '=', $this->id)->count();
     }
 
     public function getTotalFlightsHoursAttribute() {
-        $flights = Flight::where('aircraft', '=', $this->id)->get();
+        $flights = Flight::where('aircraft_id', '=', $this->id)->get();
 
         $totalFlightMinutes = 0;
 

--- a/app/Models/Airline.php
+++ b/app/Models/Airline.php
@@ -50,4 +50,8 @@ class Airline extends Model
         return $this->hasMany(Flight::class, 'airline_id');
     }
 
+    public function aircraft() {
+        return $this->hasMany(Aircraft::class, 'used_by');
+    }
+
 }

--- a/app/Models/Airline.php
+++ b/app/Models/Airline.php
@@ -5,7 +5,8 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
-
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Airline extends Model
 {
@@ -43,6 +44,10 @@ class Airline extends Model
         } else {
             return true;
         }
+    }
+
+    public function flights() {
+        return $this->hasMany(Flight::class, 'airline_id');
     }
 
 }

--- a/app/Models/Flight.php
+++ b/app/Models/Flight.php
@@ -5,7 +5,8 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use App\Models\Airline;
-
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use DateTime;
 
 class Flight extends Model
@@ -21,7 +22,11 @@ class Flight extends Model
     ];
 
     public function airline() {
-        return $this->belongsTo(Airline::class, 'airline');
+        return $this->belongsTo(Airline::class, 'airline_id');
+    }
+
+    public function aircraft() {
+        return $this->belongsTo(Aircraft::class, 'aircraft_id');
     }
 
     public function getFullFlightNumberAttribute() {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -51,7 +51,7 @@ class User extends Authenticatable
         //'airlines'
     //];
 
-    public function getHoursLogged(Airline $airline) {
+    public function getHoursLogged() {
         
     }
 

--- a/database/migrations/2024_03_18_200253_create_flights_table.php
+++ b/database/migrations/2024_03_18_200253_create_flights_table.php
@@ -15,25 +15,25 @@ class CreateFlightsTable extends Migration
     {
         Schema::create('flights', function (Blueprint $table) {
             $table->id(); # internal flight id
-            $table->foreignId('airline');
-            $table->foreign('airline')->references('id')->on('airlines');
+            $table->foreignId('airline_id');
+            $table->foreign('airline_id')->references('id')->on('airlines');
             $table->string('callsign', 4);
             $table->integer('flightnumber');
             $table->string('departure_icao', 4);
             $table->foreign('departure_icao')->references('icao_code')->on('airports');
             $table->string('arrival_icao', 4);
             $table->foreign('arrival_icao')->references('icao_code')->on('airports');
-            $table->foreignId('aircraft');
-            $table->foreign('aircraft')->references('id')->on('aircraft');
+            $table->foreignId('aircraft_id');
+            $table->foreign('aircraft_id')->references('id')->on('aircraft');
             $table->integer('crzalt');
             $table->datetime('blockoff');
             $table->datetime('blockon');
             $table->integer('burned_fuel');
             $table->text('route');
-            $table->foreignId('online_network');
-            $table->foreign('online_network')->references('id')->on('online_networks');
-            $table->foreignId('pilot');
-            $table->foreign('pilot')->references('id')->on('users');
+            $table->foreignId('online_network_id');
+            $table->foreign('online_network_id')->references('id')->on('online_networks');
+            $table->foreignId('pilot_id');
+            $table->foreign('pilot_id')->references('id')->on('users');
             $table->text('remarks')->nullable();
             $table->timestamps();
         });

--- a/database/seeders/FlightsSeeder.php
+++ b/database/seeders/FlightsSeeder.php
@@ -17,19 +17,19 @@ class FlightsSeeder extends Seeder
     public function run(): void
     {
         DB::table('flights')->insert([
-            'airline' => "1",
+            'airline_id' => "1",
             'callsign' => "1337",
             'flightnumber' => "3446",
             'departure_icao' => "EDDK",
             'arrival_icao' => 'EDDS',
-            'aircraft' => '1',
+            'aircraft_id' => '1',
             'crzalt' => '21000',
             'blockoff' => '2024-04-09 06:24:26.000000',
             'blockon' => '2024-04-09 07:15:35.000000',
             'burned_fuel' => '3185',
             'route' => 'KUMIK Y854 BOMBI T721 SUNEG T715 KRH T128 BADSO',
-            'online_network' => '3',
-            'pilot' => '2',
+            'online_network_id' => '3',
+            'pilot_id' => '2',
             'remarks' => 'Example remark',
             'created_at' => Carbon::now()->toDateTimeString(),
             'updated_at' => Carbon::now()->toDateTimeString(),

--- a/resources/views/dashboard/index.blade.php
+++ b/resources/views/dashboard/index.blade.php
@@ -15,7 +15,7 @@
             <div class="alert alert-danger" role="alert">
                 You did something nasty!
             </div>
-            @endif    
+            @endif
 
             <div class="my-4">
                 <h2 class="h4">Live Flights</h2>
@@ -24,48 +24,28 @@
                 </div>
             </div>
 
+            <ul>
+            </ul>
             <div class="my-4">
                 <h2 class="h4">Last 5 Flights of {{ session('activeairline')->name }}</h2>
                 <table class="table">
                     <thead>
                         <tr>
-                            <th scope="col">Flight</th>
-                            <th scope="col">Departure</th>
-                            <th scope="col">Arrival</th>
-                            <th scope="col">Duration</th>
+                            <th class="text-center" scope="col">Flight</th>
+                            <th class="text-center" scope="col">Callsign</th>
+                            <th class="text-center" scope="col">From / To</th>
+                            <th class="text-center" scope="col">Aircraft</th>
                         </tr>
                     </thead>
                     <tbody>
+                        @foreach($flights as $flight)
                         <tr>
-                            <td>Flight 1</td>
-                            <td>Departure 1</td>
-                            <td>Arrival 1</td>
-                            <td>Duration 1</td>
+                            <td class="text-center">{{ $flight->full_flight_number }}</td>
+                            <td class="text-center">{{ $flight->full_icao_callsign }}</td>
+                            <td class="text-center">{{ $flight->departure_icao }} <i class="bi-arrow-right"></i> {{ $flight->arrival_icao }}</td>
+                            <td class="text-center">{{ $flight->aircraft->registration }}</td>
                         </tr>
-                        <tr>
-                            <td>Flight 2</td>
-                            <td>Departure 2</td>
-                            <td>Arrival 2</td>
-                            <td>Duration 2</td>
-                        </tr>
-                        <tr>
-                            <td>Flight 3</td>
-                            <td>Departure 3</td>
-                            <td>Arrival 3</td>
-                            <td>Duration 3</td>
-                        </tr>
-                        <tr>
-                            <td>Flight 4</td>
-                            <td>Departure 4</td>
-                            <td>Arrival 4</td>
-                            <td>Duration 4</td>
-                        </tr>
-                        <tr>
-                            <td>Flight 5</td>
-                            <td>Departure 5</td>
-                            <td>Arrival 5</td>
-                            <td>Duration 5</td>
-                        </tr>
+                        @endforeach
                     </tbody>
                 </table>
             </div>


### PR DESCRIPTION
The relationship between the two models where not correct before. There was a bug, when you could only access the ID of the aircraft, but not the aircraft model itself. This is fixed in this commit.

Also, the dashboard now loads last 5 flights for the current active airline.