### PR TITLE
Add installation setup wizard and remove homebase field

### DIFF
--- a/Docs/permissions.md
+++ b/Docs/permissions.md
@@ -1,0 +1,100 @@
+# Permissions & Roles
+
+YAAMS uses a two-layer authorization system:
+
+1. **Per-airline roles** — stored in the `airline_memberships` table. Every user has exactly one role per airline they belong to. This is the primary mechanism for controlling what a user can do within a specific airline.
+2. **Global Super-Admin role** — managed by [Spatie Laravel Permission](https://spatie.be/docs/laravel-permission). A Super-Admin bypasses all permission checks across the entire instance via a `Gate::before` rule.
+
+---
+
+## Per-Airline Roles
+
+The `role` column in `airline_memberships` accepts one of three values:
+
+### Pilot
+The default role assigned to every new member. Pilots can interact with the system but cannot modify shared airline resources.
+
+**Can:**
+- File PIREPs (flight reports)
+- View their own flight history
+- View the fleet (read-only)
+- View flight details
+
+**Cannot:**
+- Review, accept, or reject PIREPs filed by other pilots
+- Add or edit aircraft
+- Manage airline membership
+
+---
+
+### Dispatcher
+A Dispatcher handles flight operations review. This role is intended for staff members who need to process incoming PIREPs without having full administrative access to the airline.
+
+**Can do everything a Pilot can, plus:**
+- View pending PIREPs in the review queue
+- Accept PIREPs
+- Reject PIREPs (with remarks)
+- Receive in-app notifications when a new PIREP is filed
+
+**Cannot:**
+- Add or edit aircraft
+- Manage airline membership
+
+---
+
+### Manager
+The airline administrator. A Manager has full control over everything within their airline.
+
+**Can do everything a Dispatcher can, plus:**
+- Add aircraft to the fleet
+- Edit aircraft details and status
+- Manage airline membership
+
+---
+
+## Permission Matrix
+
+| Action | Pilot | Dispatcher | Manager | Super-Admin |
+|---|:---:|:---:|:---:|:---:|
+| File PIREPs | ✓ | ✓ | ✓ | ✓ |
+| View fleet | ✓ | ✓ | ✓ | ✓ |
+| View flight details | ✓ | ✓ | ✓ | ✓ |
+| Review PIREPs (accept/reject) | — | ✓ | ✓ | ✓ |
+| Receive PIREP notifications | — | ✓ | ✓ | ✓ |
+| Add aircraft | — | — | ✓ | ✓ |
+| Edit aircraft | — | — | ✓ | ✓ |
+| Manage membership | — | — | ✓ | ✓ |
+| Instance-wide admin | — | — | — | ✓ |
+
+---
+
+## Super-Admin
+
+The Super-Admin role is a global, instance-wide role managed separately from per-airline roles. It is not scoped to any single airline.
+
+A Super-Admin:
+- Bypasses **all** permission checks on every airline on the instance
+- Is created automatically during the setup wizard
+- Can act as Manager in any airline without holding an explicit airline membership role
+
+> The Super-Admin role is implemented via Spatie Laravel Permission's `Gate::before` hook in `AuthServiceProvider`. It does not interact with the `airline_memberships.role` column.
+
+---
+
+## Implementation Notes
+
+Permission checks in controllers and policies use the `User::hasAirlineRole(Airline, string|array)` helper:
+
+```php
+// True for Dispatcher or Manager of the given airline
+$user->hasAirlineRole($airline, ['Dispatcher', 'Manager']);
+
+// Convenience shorthands
+$user->isManagerOf($airline);        // role = Manager
+$user->canReviewFlightsFor($airline); // role = Dispatcher or Manager
+```
+
+To add a new role in future:
+1. Add the new value to the `role` enum in a migration
+2. Add it to the relevant `hasAirlineRole()` calls in controllers/policies
+3. Document it here

--- a/app/Http/Controllers/AircraftController.php
+++ b/app/Http/Controllers/AircraftController.php
@@ -96,8 +96,8 @@ class AircraftController extends Controller
     public function create(Request $request) {
         $currentActiveAirline = $request->session()->get('activeairline');
 
-        if (!auth()->user()->can('add aircraft')) {
-            return redirect()->route('dashboard')->with('error', 'You do not have permission to add aircraft.');
+        if (!auth()->user()->isManagerOf($currentActiveAirline)) {
+            return redirect()->route('dashboard')->with('error', 'You do not have permission to add aircraft to this airline.');
         }
 
         if ($request->getMethod() == "POST") {

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -6,7 +6,6 @@ use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use App\Models\User;
 use Illuminate\Support\Facades\Hash;
-use Illuminate\Support\Str;
 
 class RegisterController extends Controller
 {
@@ -24,14 +23,12 @@ class RegisterController extends Controller
         $this->validate($request, [
             'name' => 'required|max:255|string',
             'email' => 'required|email|max:255',
-            'homebase' => 'max:4',
             'password' => 'required|confirmed'
         ]);
 
         $user = User::create([
             'name' => $request->name,
             'email' => $request->email,
-            'homebase' => Str::upper($request->homebase),
             'password' => Hash::make($request->password)
         ]);
 

--- a/app/Http/Controllers/FlightController.php
+++ b/app/Http/Controllers/FlightController.php
@@ -220,6 +220,14 @@ class FlightController extends Controller
             return redirect()->route("flightlist");
         }
 
+        // Guard: no aircraft means the form is unusable
+        if ($currentActiveAirline->activeAircraft->isEmpty()) {
+            return redirect()->route('flightlist')->with(
+                'error',
+                'You need to add an aircraft first before adding a flight!'
+            );
+        }
+
         // Get all available online networks to display in the select
         $prefill_select_online_network = OnlineNetwork::query()->get();
 

--- a/app/Http/Controllers/FlightController.php
+++ b/app/Http/Controllers/FlightController.php
@@ -261,6 +261,10 @@ class FlightController extends Controller
     {
         $currentActiveAirline = Session::get("activeairline");
 
+        if (!auth()->user()->canReviewFlightsFor($currentActiveAirline)) {
+            return redirect()->route('dashboard')->with('error', 'You do not have permission to review flights for this airline.');
+        }
+
         $flights = Flight::query()
             ->where("airline_id", $currentActiveAirline->id)
             ->where("status_id", "=", "1")
@@ -273,6 +277,10 @@ class FlightController extends Controller
     public function acceptFlight(Flight $flight)
     {
         $currentActiveAirline = Session::get("activeairline");
+
+        if (!auth()->user()->canReviewFlightsFor($currentActiveAirline)) {
+            return redirect()->route('dashboard')->with('error', 'You do not have permission to review flights for this airline.');
+        }
 
         // Is the flight part of the active airline?
         if ($currentActiveAirline->id !== $flight->airline_id) {
@@ -300,6 +308,10 @@ class FlightController extends Controller
     public function rejectFlight(Request $request, Flight $flight)
     {
         $currentActiveAirline = session()->get("activeairline");
+
+        if (!auth()->user()->canReviewFlightsFor($currentActiveAirline)) {
+            return redirect()->route('dashboard')->with('error', 'You do not have permission to review flights for this airline.');
+        }
 
         // Is the flight part of the active airline?
         if ($currentActiveAirline->id !== $flight->airline_id) {

--- a/app/Http/Controllers/SetupController.php
+++ b/app/Http/Controllers/SetupController.php
@@ -93,9 +93,10 @@ class SetupController extends Controller
 
             // Admin user
             $user = User::create([
-                'name'     => $request->admin_name,
-                'email'    => $request->admin_email,
-                'password' => Hash::make($request->admin_password),
+                'name'              => $request->admin_name,
+                'email'             => $request->admin_email,
+                'password'          => Hash::make($request->admin_password),
+                'email_verified_at' => $now,
             ]);
 
             $user->assignRole($superAdminRole);

--- a/app/Http/Controllers/SetupController.php
+++ b/app/Http/Controllers/SetupController.php
@@ -100,7 +100,7 @@ class SetupController extends Controller
             ]);
 
             $user->assignRole($superAdminRole);
-            $airline->users()->attach($user);
+            $airline->users()->attach($user, ['role' => 'Manager']);
 
             auth()->login($user);
             session(['activeairline' => $airline]);

--- a/app/Http/Controllers/SetupController.php
+++ b/app/Http/Controllers/SetupController.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Airline;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+
+class SetupController extends Controller
+{
+    public function show()
+    {
+        if (User::count() > 0) {
+            return redirect()->route('dashboard');
+        }
+
+        return view('setup.index');
+    }
+
+    public function store(Request $request)
+    {
+        if (User::count() > 0) {
+            return redirect()->route('dashboard');
+        }
+
+        $request->validate([
+            'app_name'         => 'required|string|max:255',
+            'airline_name'     => 'required|string|max:255',
+            'airline_prefix'   => 'required|string|max:2|min:2|alpha',
+            'airline_icao'     => 'required|string|max:3|min:2|alpha',
+            'airline_callsign' => 'required|alpha|min:2|max:10',
+            'unit_is_lbs'      => 'nullable|boolean',
+            'admin_name'       => 'required|string|max:255',
+            'admin_email'      => 'required|email|max:255',
+            'admin_password'   => 'required|confirmed|min:8',
+        ]);
+
+        // Import airports outside the main transaction — large bulk insert
+        DB::unprepared(file_get_contents(base_path('resources/db/airports.sql')));
+
+        DB::transaction(function () use ($request) {
+            // Roles & permissions
+            $pilotRole      = Role::firstOrCreate(['name' => 'Pilot',       'guard_name' => 'web']);
+            $managerRole    = Role::firstOrCreate(['name' => 'Manager',     'guard_name' => 'web']);
+            $superAdminRole = Role::firstOrCreate(['name' => 'Super-Admin', 'guard_name' => 'web']);
+
+            $addAircraft  = Permission::firstOrCreate(['name' => 'add aircraft',  'guard_name' => 'web']);
+            $editAircraft = Permission::firstOrCreate(['name' => 'edit aircraft', 'guard_name' => 'web']);
+            $reviewFlight = Permission::firstOrCreate(['name' => 'review flight', 'guard_name' => 'web']);
+
+            $managerRole->syncPermissions([$addAircraft, $editAircraft, $reviewFlight]);
+
+            // Flight statuses (normally seeded; create them here for fresh installs)
+            $now = Carbon::now()->toDateTimeString();
+            DB::table('flight_statuses')->insertOrIgnore([
+                ['id' => 1, 'name' => 'New',      'created_at' => $now, 'updated_at' => $now],
+                ['id' => 2, 'name' => 'Accepted', 'created_at' => $now, 'updated_at' => $now],
+                ['id' => 3, 'name' => 'Rejected', 'created_at' => $now, 'updated_at' => $now],
+                ['id' => 4, 'name' => 'Enroute',  'created_at' => $now, 'updated_at' => $now],
+            ]);
+
+            // Online networks
+            DB::table('online_networks')->insertOrIgnore([
+                ['networkname' => 'Offline',    'created_at' => $now, 'updated_at' => $now],
+                ['networkname' => 'VATSIM',     'created_at' => $now, 'updated_at' => $now],
+                ['networkname' => 'IVAO',       'created_at' => $now, 'updated_at' => $now],
+                ['networkname' => 'PilotEdge',  'created_at' => $now, 'updated_at' => $now],
+            ]);
+
+            // Instance name
+            DB::table('settings')->upsert(
+                ['key' => 'app_name', 'value' => $request->app_name, 'created_at' => $now, 'updated_at' => $now],
+                ['key'],
+                ['value', 'updated_at']
+            );
+
+            // Airline
+            $icao     = strtoupper($request->airline_icao);
+            $callsign = strtoupper($request->airline_callsign);
+
+            $airline = Airline::create([
+                'name'          => $request->airline_name,
+                'prefix'        => strtoupper($request->airline_prefix),
+                'icao_callsign' => $icao,
+                'atc_callsign'  => $callsign,
+                'unit_is_lbs'   => $request->boolean('unit_is_lbs'),
+            ]);
+
+            // Admin user
+            $user = User::create([
+                'name'     => $request->admin_name,
+                'email'    => $request->admin_email,
+                'password' => Hash::make($request->admin_password),
+            ]);
+
+            $user->assignRole($superAdminRole);
+            $airline->users()->attach($user);
+
+            auth()->login($user);
+            session(['activeairline' => $airline]);
+        });
+
+        return redirect()->route('dashboard')->with('setup_complete', true);
+    }
+}

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -38,6 +38,7 @@ class Kernel extends HttpKernel
             \App\Http\Middleware\VerifyCsrfToken::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
             \App\Http\Middleware\LastSeenUserActivity::class,
+            \App\Http\Middleware\EnsureSetupComplete::class,
         ],
 
         'api' => [

--- a/app/Http/Middleware/EnsureSetupComplete.php
+++ b/app/Http/Middleware/EnsureSetupComplete.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\User;
+use Closure;
+use Illuminate\Http\Request;
+
+class EnsureSetupComplete
+{
+    public function handle(Request $request, Closure $next)
+    {
+        if (User::count() === 0 && !$request->routeIs('setup.*')) {
+            return redirect()->route('setup.index');
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Resources/V1/UserResource.php
+++ b/app/Http/Resources/V1/UserResource.php
@@ -18,7 +18,6 @@ class UserResource extends JsonResource
             'id' => $this->id,
             'name' => $this->name,
             'email' => $this->email,
-            'homebase' => $this->homebase,
         ];
     }
 }

--- a/app/Listeners/FlightFiledNotification.php
+++ b/app/Listeners/FlightFiledNotification.php
@@ -4,7 +4,6 @@ namespace App\Listeners;
 
 use App\Events\FlightFiled;
 use App\Models\Notification;
-use App\Models\User;
 
 class FlightFiledNotification
 {
@@ -24,9 +23,9 @@ class FlightFiledNotification
         $airline = $flight->airline;
         $pilot = $flight->pilot;
 
-        // Find all users in this airline who have the 'review flight' permission
+        // Find all Dispatchers and Managers in this airline
         $reviewers = $airline->users()
-            ->whereIn('users.id', User::permission('review flight')->pluck('id'))
+            ->wherePivotIn('role', ['Dispatcher', 'Manager'])
             ->get();
 
         foreach ($reviewers as $reviewer) {

--- a/app/Models/Airline.php
+++ b/app/Models/Airline.php
@@ -25,7 +25,8 @@ class Airline extends Model
      */
     public function users(): BelongsToMany
     {
-        return $this->belongsToMany(User::class, 'airline_memberships', 'airline_id', 'user_id');
+        return $this->belongsToMany(User::class, 'airline_memberships', 'airline_id', 'user_id')
+                    ->withPivot('role');
     }
 
     /***

--- a/app/Models/AirlineMembership.php
+++ b/app/Models/AirlineMembership.php
@@ -11,7 +11,8 @@ class AirlineMembership extends Model
 
     protected $fillable = [
         'airline_id',
-        'user_id'
+        'user_id',
+        'role',
     ];
 
     public function airline()

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -24,6 +24,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'email_verified_at',
     ];
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -24,7 +24,6 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
-        'homebase',
     ];
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -79,12 +79,31 @@ class User extends Authenticatable
 
     public function airlines(): BelongsToMany
     {
-        return $this->belongsToMany(Airline::class, 'airline_memberships', 'user_id', 'airline_id');
+        return $this->belongsToMany(Airline::class, 'airline_memberships', 'user_id', 'airline_id')
+                    ->withPivot('role');
     }
 
-    public function isMemberOf(Airline $airline) : bool
+    public function isMemberOf(Airline $airline): bool
     {
         return $this->airlines()->where('airline_id', $airline->id)->exists();
+    }
+
+    public function hasAirlineRole(Airline $airline, string|array $roles): bool
+    {
+        return $this->airlines()
+            ->where('airline_id', $airline->id)
+            ->wherePivotIn('role', (array) $roles)
+            ->exists();
+    }
+
+    public function isManagerOf(Airline $airline): bool
+    {
+        return $this->hasAirlineRole($airline, 'Manager');
+    }
+
+    public function canReviewFlightsFor(Airline $airline): bool
+    {
+        return $this->hasAirlineRole($airline, ['Dispatcher', 'Manager']);
     }
 
     public function notifications()

--- a/app/Policies/AircraftPolicy.php
+++ b/app/Policies/AircraftPolicy.php
@@ -30,6 +30,6 @@ class AircraftPolicy
     public function update(User $user, Aircraft $aircraft): bool
     {
         $activeAirline = session('activeairline');
-        return $user->can('edit aircraft') && $activeAirline && $aircraft->ownedBy($activeAirline);
+        return $activeAirline && $aircraft->ownedBy($activeAirline) && $user->isManagerOf($activeAirline);
     }
 }

--- a/database/migrations/2026_06_23_225516_create_settings_table.php
+++ b/database/migrations/2026_06_23_225516_create_settings_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('settings', function (Blueprint $table) {
+            $table->string('key')->primary();
+            $table->text('value')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('settings');
+    }
+};

--- a/database/migrations/2026_06_23_230608_drop_homebase_from_users_table.php
+++ b/database/migrations/2026_06_23_230608_drop_homebase_from_users_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropForeign(['homebase']);
+            $table->dropColumn('homebase');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('homebase', 4)->nullable();
+            $table->foreign('homebase')->references('icao_code')->on('airports');
+        });
+    }
+};

--- a/database/migrations/2026_06_23_233710_add_role_to_airline_memberships_table.php
+++ b/database/migrations/2026_06_23_233710_add_role_to_airline_memberships_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('airline_memberships', function (Blueprint $table) {
+            $table->enum('role', ['Pilot', 'Dispatcher', 'Manager'])->default('Pilot')->after('user_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('airline_memberships', function (Blueprint $table) {
+            $table->dropColumn('role');
+        });
+    }
+};

--- a/database/seeders/AirlineMembershipSeeder.php
+++ b/database/seeders/AirlineMembershipSeeder.php
@@ -15,43 +15,19 @@ class AirlineMembershipSeeder extends Seeder
      */
     public function run(): void
     {
-        // Max Mustermann is member of the two demo airlines
-        DB::table('airline_memberships')->insert([
-            'airline_id' => "2",
-            'user_id' => "2",
-            'created_at' => Carbon::now()->toDateTimeString(),
-            'updated_at' => Carbon::now()->toDateTimeString(),
-        ]);
-        DB::table('airline_memberships')->insert([
-            'airline_id' => "1",
-            'user_id' => "2",
-            'created_at' => Carbon::now()->toDateTimeString(),
-            'updated_at' => Carbon::now()->toDateTimeString(),
-        ]);
-        DB::table('airline_memberships')->insert([
-            'airline_id' => "3",
-            'user_id' => "1",
-            'created_at' => Carbon::now()->toDateTimeString(),
-            'updated_at' => Carbon::now()->toDateTimeString(),
-        ]);
-        DB::table('airline_memberships')->insert([
-            'airline_id' => "1",
-            'user_id' => "3",
-            'created_at' => Carbon::now()->toDateTimeString(),
-            'updated_at' => Carbon::now()->toDateTimeString(),
-        ]);
-        DB::table('airline_memberships')->insert([
-            'airline_id' => "2",
-            'user_id' => "3",
-            'created_at' => Carbon::now()->toDateTimeString(),
-            'updated_at' => Carbon::now()->toDateTimeString(),
-        ]);
-        DB::table('airline_memberships')->insert([
-            'airline_id' => "3",
-            'user_id' => "3",
-            'created_at' => Carbon::now()->toDateTimeString(),
-            'updated_at' => Carbon::now()->toDateTimeString(),
-        ]);
+        $now = Carbon::now()->toDateTimeString();
+
+        // Max Mustermann: Dispatcher on airline 1, Manager on airline 2
+        DB::table('airline_memberships')->insert(['airline_id' => 1, 'user_id' => 2, 'role' => 'Dispatcher', 'created_at' => $now, 'updated_at' => $now]);
+        DB::table('airline_memberships')->insert(['airline_id' => 2, 'user_id' => 2, 'role' => 'Manager',    'created_at' => $now, 'updated_at' => $now]);
+
+        // Homer Simpson: Pilot on airline 3
+        DB::table('airline_memberships')->insert(['airline_id' => 3, 'user_id' => 1, 'role' => 'Pilot',     'created_at' => $now, 'updated_at' => $now]);
+
+        // Admin: Manager on all three demo airlines (Super-Admin bypasses anyway)
+        DB::table('airline_memberships')->insert(['airline_id' => 1, 'user_id' => 3, 'role' => 'Manager',   'created_at' => $now, 'updated_at' => $now]);
+        DB::table('airline_memberships')->insert(['airline_id' => 2, 'user_id' => 3, 'role' => 'Manager',   'created_at' => $now, 'updated_at' => $now]);
+        DB::table('airline_memberships')->insert(['airline_id' => 3, 'user_id' => 3, 'role' => 'Manager',   'created_at' => $now, 'updated_at' => $now]);
 
         // Randomly assign existing users (Homer: 1, Max: 2, Admin: 3) to new airlines (4 to 10)
         for ($airlineId = 4; $airlineId <= 10; $airlineId++) {
@@ -61,8 +37,9 @@ class AirlineMembershipSeeder extends Seeder
                     DB::table('airline_memberships')->insert([
                         'airline_id' => $airlineId,
                         'user_id' => $userId,
-                        'created_at' => Carbon::now()->toDateTimeString(),
-                        'updated_at' => Carbon::now()->toDateTimeString(),
+                        'role' => 'Pilot',
+                        'created_at' => $now,
+                        'updated_at' => $now,
                     ]);
                 }
             }

--- a/database/seeders/UserAndPermissionsSeeder.php
+++ b/database/seeders/UserAndPermissionsSeeder.php
@@ -44,7 +44,6 @@ class UserAndPermissionsSeeder extends Seeder
             'name' => 'Homer Simpson',
             'email' => 'homer@test.com',
             'password' => Hash::make('start'),
-            'homebase' => 'EDDF'
         ]);
         $user->assignRole($role1);
         $generatedToken = $user->createToken("homertoken")->plainTextToken;
@@ -54,7 +53,6 @@ class UserAndPermissionsSeeder extends Seeder
             'name' => 'Max Mustermann',
             'email' => 'test@test.com',
             'password' => Hash::make('start'),
-            'homebase' => 'EDDF'
         ]);
         $user->assignRole($role2);
         $generatedToken = $user->createToken("maxtoken")->plainTextToken;
@@ -64,7 +62,6 @@ class UserAndPermissionsSeeder extends Seeder
             'name' => 'Admin',
             'email' => 'admin@test.com',
             'password' => Hash::make('start'),
-            'homebase' => 'EDDM'
         ]);
         $user->assignRole($role3);
         $generatedToken = $user->createToken("admintoken")->plainTextToken;

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -45,19 +45,6 @@
             </div>
 
             <div class="mb-3">
-                <label for="homebase" class="form-label">Home base (ICAO code)</label>
-                <div class="input-group">
-                    <span class="input-group-text"><i class="bi bi-geo-alt text-secondary"></i></span>
-                    <input type="text" id="homebase" class="form-control @error('homebase') is-invalid @enderror" name="homebase" placeholder="e.g. EDDK" required value="{{ old('homebase') }}">
-                </div>
-                @error('homebase')
-                    <div class="invalid-feedback d-block mt-1">
-                        {{ $message }}
-                    </div>
-                @enderror
-            </div>
-
-            <div class="mb-3">
                 <label for="password" class="form-label">Password</label>
                 <div class="input-group">
                     <span class="input-group-text"><i class="bi bi-lock text-secondary"></i></span>

--- a/resources/views/dashboard/index.blade.php
+++ b/resources/views/dashboard/index.blade.php
@@ -71,7 +71,7 @@
                 <i class="bi bi-shield-slash-fill fs-4 text-danger"></i>
                 <div>
                     <h6 class="alert-heading fw-bold mb-1">An error occurred</h6>
-                    <p class="small mb-0 text-secondary">Something went sideways! Please try again or contact an admin.</p>
+                    <p class="small mb-0 text-secondary">{{ session('error') }}</p>
                 </div>
             </div>
         @endif

--- a/resources/views/fleet/detail.blade.php
+++ b/resources/views/fleet/detail.blade.php
@@ -32,11 +32,11 @@
             </p>
         </div>
         <div>
-            @can('edit aircraft')
+            @if(session('activeairline') && auth()->user()->isManagerOf(session('activeairline')))
                 <a href="{{ route('editaircraft', $aircraft->id) }}" class="btn btn-outline-primary me-2">
                     <i class="bi bi-pencil-square me-1"></i> Edit Aircraft
                 </a>
-            @endcan
+            @endif
             <a href="{{ route('fleetmanager') }}" class="btn btn-secondary">
                 <i class="bi bi-arrow-left me-1"></i> Back to Fleet
             </a>

--- a/resources/views/fleet/index.blade.php
+++ b/resources/views/fleet/index.blade.php
@@ -45,13 +45,13 @@
                 <h1 class="display-5 fw-bold text-dark tracking-tight mb-1">Fleet Overview</h1>
                 <p class="text-muted lead mb-0 fs-6">Monitor all operational aircraft and their current hubs based on recent flight logs.</p>
             </div>
-            @can('add aircraft')
+            @if(session('activeairline') && auth()->user()->isManagerOf(session('activeairline')))
                 <div>
                     <a href="{{ route('createaircraft') }}" class="btn btn-success px-4 py-2 d-inline-flex align-items-center gap-2 shadow-sm">
                         <i class="bi bi-plus-circle"></i> Add Aircraft
                     </a>
                 </div>
-            @endcan
+            @endif
         </div>
 
         @if($errors->any())
@@ -124,9 +124,9 @@
                                             Status {!! sortIcon('active') !!}
                                         </a>
                                     </th>
-                                    @can('edit aircraft')
+                                    @if(session('activeairline') && auth()->user()->isManagerOf(session('activeairline')))
                                     <th scope="col" class="py-3 text-end pe-4">Actions</th>
-                                    @endcan
+                                    @endif
                                 </tr>
                             </thead>
                             <tbody class="fs-6">
@@ -166,13 +166,13 @@
                                             @endif
                                         </td>
                                         
-                                        @can('edit aircraft')
+                                        @if(session('activeairline') && auth()->user()->isManagerOf(session('activeairline')))
                                             <td class="py-3 text-end pe-4">
                                                 <a href="{{ route('editaircraft', $aircraft->id) }}" class="btn btn-sm btn-outline-secondary px-2.5 py-1 shadow-xs fs-7">
                                                     <i class="bi bi-pencil-square"></i> Edit
                                                 </a>
                                             </td>
-                                        @endcan
+                                        @endif
                                     </tr>
                                 @endforeach
                             </tbody>                    
@@ -221,11 +221,11 @@
                     @else
                         <h5 class="fw-bold text-dark mb-1">No Aircraft Found</h5>
                         <p class="text-secondary small max-w-md mx-auto mb-3">Your airline fleet is currently empty. Get started by registering your first airframe.</p>
-                        @can('add aircraft')
+                        @if(session('activeairline') && auth()->user()->isManagerOf(session('activeairline')))
                             <a href="{{ route('createaircraft') }}" class="btn btn-sm btn-success px-3 shadow-sm">
                                 Add First Aircraft
                             </a>
-                        @endcan
+                        @endif
                     @endif
                 </div>
             </div>

--- a/resources/views/flights/list.blade.php
+++ b/resources/views/flights/list.blade.php
@@ -55,6 +55,13 @@
             </div>
         </div>
 
+        @if (session('error'))
+        <div class="alert alert-danger alert-dismissible fade show shadow-sm mb-4" role="alert">
+            <i class="bi bi-exclamation-triangle-fill me-2"></i> {{ session('error') }}
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+        @endif
+
         @if($errors->any())
         <div class="alert alert-danger alert-dismissible fade show shadow-sm mb-4" role="alert">
             <h4 class="alert-heading fs-6 fw-bold"><i class="bi bi-exclamation-triangle-fill me-2"></i> Error during request</h4>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -73,10 +73,10 @@
                         <ul class="dropdown-menu shadow-sm border-0" aria-labelledby="navbarDropdownFlights">
                             <li><a class="dropdown-item" href="{{ route('flightlist') }}">My PIREPs</a></li>
                             <li><a class="dropdown-item" href="{{ route('flightadd') }}">File a PIREP</a></li>
-                            @can('review flight')
+                            @if(session('activeairline') && auth()->user()->canReviewFlightsFor(session('activeairline')))
                             <li><hr class="dropdown-divider"></li>
                             <li><a class="dropdown-item" href="{{ route('flightreviewindex') }}">Review flights</a></li>
-                            @endcan
+                            @endif
                         </ul>
                     </li>
                     <li class="nav-item">

--- a/resources/views/layouts/setuplayout.blade.php
+++ b/resources/views/layouts/setuplayout.blade.php
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>@yield('title', 'YAAMS Setup')</title>
+
+    <link rel="icon" href="{{ asset('favicon.ico') }}">
+
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+
+    <style>
+        body {
+            background-color: #f4f6f9;
+            color: #333;
+            min-height: 100vh;
+            display: flex;
+            align-items: flex-start;
+            justify-content: center;
+            padding: 2rem 1rem;
+        }
+        .setup-container {
+            width: 100%;
+            max-width: 640px;
+        }
+        .card {
+            border: none;
+            box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.05);
+            border-radius: 0.5rem;
+        }
+        .form-control:focus {
+            box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.15);
+        }
+        .btn-primary {
+            background-color: #0d6efd;
+            border: none;
+            padding: 0.75rem;
+            font-weight: 600;
+        }
+        .section-icon {
+            width: 2rem;
+            height: 2rem;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            border-radius: 50%;
+            font-size: 0.9rem;
+        }
+        .step-divider {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            margin: 1.75rem 0;
+            color: #6c757d;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+        }
+        .step-divider::before,
+        .step-divider::after {
+            content: '';
+            flex: 1;
+            border-top: 1px solid #dee2e6;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="setup-container">
+        @yield('content')
+        <div class="text-center mt-4">
+            <small class="text-muted">&copy; {{ date('Y') }} YAAMS Virtual Airline Management</small>
+        </div>
+    </div>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/umd/popper.min.js" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+</body>
+</html>

--- a/resources/views/setup/index.blade.php
+++ b/resources/views/setup/index.blade.php
@@ -1,0 +1,240 @@
+@extends('layouts.setuplayout')
+@section('title', 'YAAMS Setup Wizard')
+@section('content')
+
+<div class="text-center mb-4">
+    <img src="{{ asset('img/yaams-temp-logo.png') }}" alt="YAAMS Logo" height="60" class="mb-3">
+    <h1 class="h4 fw-bold mb-1">Welcome to YAAMS</h1>
+    <p class="text-muted small">Complete the setup below to get started.</p>
+</div>
+
+<div class="card shadow-sm">
+    <div class="card-body p-4">
+
+        <form action="{{ route('setup.store') }}" method="post">
+            @csrf
+
+            @if ($errors->any())
+                <div class="alert alert-danger mb-4">
+                    <ul class="mb-0 ps-3">
+                        @foreach ($errors->all() as $error)
+                            <li>{{ $error }}</li>
+                        @endforeach
+                    </ul>
+                </div>
+            @endif
+
+            {{-- Section 1: Instance --}}
+            <div class="d-flex align-items-center gap-2 mb-3">
+                <span class="section-icon bg-primary bg-opacity-10 text-primary">
+                    <i class="bi bi-globe2"></i>
+                </span>
+                <h6 class="mb-0 fw-semibold">Your YAAMS Instance</h6>
+            </div>
+
+            <div class="mb-3">
+                <label for="app_name" class="form-label">Instance name</label>
+                <div class="input-group">
+                    <span class="input-group-text"><i class="bi bi-tag text-secondary"></i></span>
+                    <input type="text"
+                           id="app_name"
+                           name="app_name"
+                           class="form-control @error('app_name') is-invalid @enderror"
+                           placeholder="e.g. FlySimWorld Virtual Airlines"
+                           value="{{ old('app_name') }}"
+                           required>
+                </div>
+                @error('app_name')
+                    <div class="invalid-feedback d-block mt-1">{{ $message }}</div>
+                @enderror
+                <div class="form-text">Shown in the page title and header across the app.</div>
+            </div>
+
+            {{-- Section 2: Airline --}}
+            <div class="step-divider">
+                <span class="section-icon bg-success bg-opacity-10 text-success">
+                    <i class="bi bi-airplane-fill"></i>
+                </span>
+                Your First Airline
+            </div>
+
+            <div class="mb-3">
+                <label for="airline_name" class="form-label">Airline name</label>
+                <div class="input-group">
+                    <span class="input-group-text"><i class="bi bi-building text-secondary"></i></span>
+                    <input type="text"
+                           id="airline_name"
+                           name="airline_name"
+                           class="form-control @error('airline_name') is-invalid @enderror"
+                           placeholder="e.g. FlySimWorld Airlines"
+                           value="{{ old('airline_name') }}"
+                           required>
+                </div>
+                @error('airline_name')
+                    <div class="invalid-feedback d-block mt-1">{{ $message }}</div>
+                @enderror
+            </div>
+
+            <div class="row g-3 mb-3">
+                <div class="col-sm-4">
+                    <label for="airline_prefix" class="form-label">IATA prefix <span class="text-muted fw-normal">(2 letters)</span></label>
+                    <div class="input-group">
+                        <span class="input-group-text"><i class="bi bi-hash text-secondary"></i></span>
+                        <input type="text"
+                               id="airline_prefix"
+                               name="airline_prefix"
+                               class="form-control text-uppercase @error('airline_prefix') is-invalid @enderror"
+                               placeholder="FW"
+                               maxlength="2"
+                               value="{{ old('airline_prefix') }}"
+                               required>
+                    </div>
+                    @error('airline_prefix')
+                        <div class="invalid-feedback d-block mt-1">{{ $message }}</div>
+                    @enderror
+                </div>
+                <div class="col-sm-4">
+                    <label for="airline_icao" class="form-label">ICAO callsign <span class="text-muted fw-normal">(3 letters)</span></label>
+                    <div class="input-group">
+                        <span class="input-group-text"><i class="bi bi-broadcast text-secondary"></i></span>
+                        <input type="text"
+                               id="airline_icao"
+                               name="airline_icao"
+                               class="form-control text-uppercase @error('airline_icao') is-invalid @enderror"
+                               placeholder="FSW"
+                               maxlength="3"
+                               value="{{ old('airline_icao') }}"
+                               required>
+                    </div>
+                    @error('airline_icao')
+                        <div class="invalid-feedback d-block mt-1">{{ $message }}</div>
+                    @enderror
+                </div>
+                <div class="col-sm-4">
+                    <label for="airline_callsign" class="form-label">ATC callsign</label>
+                    <div class="input-group">
+                        <span class="input-group-text"><i class="bi bi-mic text-secondary"></i></span>
+                        <input type="text"
+                               id="airline_callsign"
+                               name="airline_callsign"
+                               class="form-control text-uppercase @error('airline_callsign') is-invalid @enderror"
+                               placeholder="FLYSIM"
+                               maxlength="10"
+                               style="text-transform: uppercase"
+                               oninput="this.value = this.value.toUpperCase().replace(/[^A-Z]/g, '')"
+                               value="{{ old('airline_callsign') }}"
+                               data-bs-toggle="tooltip"
+                               data-bs-trigger="focus"
+                               data-bs-placement="top"
+                               title="Letters only, 2–10 chars (e.g. SPEEDBIRD)"
+                               required>
+                    </div>
+                    @error('airline_callsign')
+                        <div class="invalid-feedback d-block mt-1">{{ $message }}</div>
+                    @enderror
+                </div>
+            </div>
+
+            <div class="mb-3">
+                <label class="form-label d-block">Weight unit</label>
+                <div class="btn-group w-100" role="group">
+                    <input type="radio" class="btn-check" name="unit_is_lbs" id="unit_kg" value="0"
+                           {{ old('unit_is_lbs', '0') === '0' ? 'checked' : '' }}>
+                    <label class="btn btn-outline-secondary" for="unit_kg">
+                        <i class="bi bi-thermometer-half me-1"></i> Kilograms (kg)
+                    </label>
+
+                    <input type="radio" class="btn-check" name="unit_is_lbs" id="unit_lbs" value="1"
+                           {{ old('unit_is_lbs') === '1' ? 'checked' : '' }}>
+                    <label class="btn btn-outline-secondary" for="unit_lbs">
+                        <i class="bi bi-thermometer-half me-1"></i> Pounds (lbs)
+                    </label>
+                </div>
+            </div>
+
+            {{-- Section 3: Admin account --}}
+            <div class="step-divider">
+                <span class="section-icon bg-warning bg-opacity-10 text-warning">
+                    <i class="bi bi-person-badge-fill"></i>
+                </span>
+                Admin Account
+            </div>
+
+            <div class="mb-3">
+                <label for="admin_name" class="form-label">Full name</label>
+                <div class="input-group">
+                    <span class="input-group-text"><i class="bi bi-person text-secondary"></i></span>
+                    <input type="text"
+                           id="admin_name"
+                           name="admin_name"
+                           class="form-control @error('admin_name') is-invalid @enderror"
+                           placeholder="John Doe"
+                           value="{{ old('admin_name') }}"
+                           required>
+                </div>
+                @error('admin_name')
+                    <div class="invalid-feedback d-block mt-1">{{ $message }}</div>
+                @enderror
+            </div>
+
+            <div class="mb-3">
+                <label for="admin_email" class="form-label">Email address</label>
+                <div class="input-group">
+                    <span class="input-group-text"><i class="bi bi-envelope text-secondary"></i></span>
+                    <input type="email"
+                           id="admin_email"
+                           name="admin_email"
+                           class="form-control @error('admin_email') is-invalid @enderror"
+                           placeholder="admin@example.com"
+                           value="{{ old('admin_email') }}"
+                           required>
+                </div>
+                @error('admin_email')
+                    <div class="invalid-feedback d-block mt-1">{{ $message }}</div>
+                @enderror
+            </div>
+
+            <div class="mb-3">
+                <label for="admin_password" class="form-label">Password</label>
+                <div class="input-group">
+                    <span class="input-group-text"><i class="bi bi-lock text-secondary"></i></span>
+                    <input type="password"
+                           id="admin_password"
+                           name="admin_password"
+                           class="form-control @error('admin_password') is-invalid @enderror"
+                           placeholder="Min. 8 characters"
+                           required>
+                </div>
+                @error('admin_password')
+                    <div class="invalid-feedback d-block mt-1">{{ $message }}</div>
+                @enderror
+            </div>
+
+            <div class="mb-4">
+                <label for="admin_password_confirmation" class="form-label">Confirm password</label>
+                <div class="input-group">
+                    <span class="input-group-text"><i class="bi bi-lock-fill text-secondary"></i></span>
+                    <input type="password"
+                           id="admin_password_confirmation"
+                           name="admin_password_confirmation"
+                           class="form-control"
+                           placeholder="Repeat password"
+                           required>
+                </div>
+            </div>
+
+            <button class="btn btn-primary w-100" type="submit">
+                <i class="bi bi-check2-circle me-2"></i> Complete Setup
+            </button>
+        </form>
+
+    </div>
+</div>
+
+<script>
+    document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => {
+        new bootstrap.Tooltip(el)
+    })
+</script>
+
+@endsection

--- a/resources/views/setup/index.blade.php
+++ b/resources/views/setup/index.blade.php
@@ -66,7 +66,7 @@
                            id="airline_name"
                            name="airline_name"
                            class="form-control @error('airline_name') is-invalid @enderror"
-                           placeholder="e.g. FlySimWorld Airlines"
+                           placeholder="e.g. My virtual airline"
                            value="{{ old('airline_name') }}"
                            required>
                 </div>
@@ -84,7 +84,7 @@
                                id="airline_prefix"
                                name="airline_prefix"
                                class="form-control text-uppercase @error('airline_prefix') is-invalid @enderror"
-                               placeholder="FW"
+                               placeholder="VA"
                                maxlength="2"
                                value="{{ old('airline_prefix') }}"
                                required>
@@ -101,7 +101,7 @@
                                id="airline_icao"
                                name="airline_icao"
                                class="form-control text-uppercase @error('airline_icao') is-invalid @enderror"
-                               placeholder="FSW"
+                               placeholder="MVA"
                                maxlength="3"
                                value="{{ old('airline_icao') }}"
                                required>
@@ -118,7 +118,7 @@
                                id="airline_callsign"
                                name="airline_callsign"
                                class="form-control text-uppercase @error('airline_callsign') is-invalid @enderror"
-                               placeholder="FLYSIM"
+                               placeholder="VIRTUAL"
                                maxlength="10"
                                style="text-transform: uppercase"
                                oninput="this.value = this.value.toUpperCase().replace(/[^A-Z]/g, '')"

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,11 @@ use App\Http\Controllers\FlightController;
 use App\Http\Controllers\AircraftController;
 use App\Http\Controllers\AirlineMembershipController;
 use App\Http\Controllers\NotificationsController;
+use App\Http\Controllers\SetupController;
+
+// Setup wizard — only accessible before any user exists
+Route::get('/setup', [SetupController::class, 'show'])->name('setup.index');
+Route::post('/setup', [SetupController::class, 'store'])->name('setup.store');
 
 // Global Welcome / Guest landing page
 Route::get("/", function () {


### PR DESCRIPTION
Introduce a one-time /setup wizard that runs on fresh installs (detected by User::count() === 0 via EnsureSetupComplete middleware). The wizard bootstraps all reference data — roles, permissions, flight statuses, online networks, and the full airports database — then creates the first airline and a Super-Admin user in a single transaction.

- Add settings table (key/value) to store the instance name
- Guard flight filing with a clear error when no aircraft exists yet
- Remove the homebase field from users entirely (model, API resource, register form, seeder, and a drop-column migration)