### PR TITLE
Add instance settings page and enrich admin dashboard

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\Fortify;
 
+use App\Models\Setting;
 use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
@@ -11,6 +12,10 @@ class CreateNewUser implements CreatesNewUsers
 {
     public function create(array $input): User
     {
+        // Defend the registration endpoint even if the form is bypassed —
+        // the instance-wide toggle lives in the settings table.
+        abort_if(Setting::get('allow_registration', '1') !== '1', 403, 'Registration is currently closed.');
+
         Validator::make($input, [
             'name'     => ['required', 'string', 'max:255'],
             'email'    => ['required', 'string', 'email', 'max:255', 'unique:users'],

--- a/app/Http/Controllers/Admin/AdminController.php
+++ b/app/Http/Controllers/Admin/AdminController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\Aircraft;
 use App\Models\Airline;
 use App\Models\Flight;
+use App\Models\Setting;
 use App\Models\User;
 
 class AdminController extends Controller
@@ -19,14 +20,24 @@ class AdminController extends Controller
     public function index()
     {
         $stats = [
-            'users'    => User::count(),
-            'airlines' => Airline::count(),
-            'flights'  => Flight::count(),
-            'aircraft' => Aircraft::count(),
+            'users'         => User::count(),
+            'airlines'      => Airline::count(),
+            'flights'       => Flight::count(),
+            'aircraft'      => Aircraft::count(),
+            'pendingPireps' => Flight::where('status_id', 1)->count(),
+            'acceptedFlights' => Flight::where('status_id', 2)->count(),
         ];
 
-        $recentUsers = User::latest()->take(5)->get();
+        $recentUsers    = User::latest()->take(5)->get();
+        $recentAirlines = Airline::latest()->take(5)->get();
 
-        return view('admin.index', compact('stats', 'recentUsers'));
+        $instance = [
+            'app_name'                    => Setting::get('app_name'),
+            'allow_registration'          => Setting::get('allow_registration') === '1',
+            'allow_user_airline_creation' => Setting::get('allow_user_airline_creation') === '1',
+            'support_email'               => Setting::get('support_email'),
+        ];
+
+        return view('admin.index', compact('stats', 'recentUsers', 'recentAirlines', 'instance'));
     }
 }

--- a/app/Http/Controllers/Admin/SettingsController.php
+++ b/app/Http/Controllers/Admin/SettingsController.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Setting;
+use Illuminate\Http\Request;
+
+class SettingsController extends Controller
+{
+    /**
+     * Instance settings form — edits the key/value rows in the `settings`
+     * table. Access is restricted to Super-Admins via the `role:Super-Admin`
+     * middleware on the route group (see routes/web.php).
+     */
+    public function edit()
+    {
+        $settings = [
+            'app_name'                    => Setting::get('app_name'),
+            'allow_user_airline_creation' => Setting::get('allow_user_airline_creation'),
+            'allow_registration'          => Setting::get('allow_registration'),
+            'support_email'               => Setting::get('support_email'),
+        ];
+
+        return view('admin.settings', compact('settings'));
+    }
+
+    public function update(Request $request)
+    {
+        $validated = $request->validate([
+            'app_name'                    => 'required|string|max:255',
+            'allow_user_airline_creation' => 'required|boolean',
+            'allow_registration'          => 'required|boolean',
+            'support_email'               => 'nullable|email|max:255',
+        ]);
+
+        Setting::set('app_name', $validated['app_name']);
+        Setting::set('allow_user_airline_creation', $request->boolean('allow_user_airline_creation') ? '1' : '0');
+        Setting::set('allow_registration', $request->boolean('allow_registration') ? '1' : '0');
+        Setting::set('support_email', $validated['support_email'] ?? null);
+
+        return redirect()
+            ->route('admin.settings.edit')
+            ->with('status', 'Instance settings saved.');
+    }
+}

--- a/app/Http/Controllers/SetupController.php
+++ b/app/Http/Controllers/SetupController.php
@@ -44,6 +44,8 @@ class SetupController extends Controller
             'airline_founded'  => 'nullable|date',
             'unit_is_lbs'                  => 'nullable|boolean',
             'allow_user_airline_creation'  => 'required|boolean',
+            'allow_registration'           => 'required|boolean',
+            'support_email'                => 'nullable|email|max:255',
             'admin_name'                   => 'required|string|max:255',
             'admin_email'      => 'required|email|max:255',
             'admin_password'   => 'required|confirmed|min:8',
@@ -82,6 +84,8 @@ class SetupController extends Controller
             DB::table('settings')->upsert([
                 ['key' => 'app_name',                    'value' => $request->app_name,                                          'created_at' => $now, 'updated_at' => $now],
                 ['key' => 'allow_user_airline_creation', 'value' => $request->boolean('allow_user_airline_creation') ? '1' : '0', 'created_at' => $now, 'updated_at' => $now],
+                ['key' => 'allow_registration',          'value' => $request->boolean('allow_registration') ? '1' : '0',          'created_at' => $now, 'updated_at' => $now],
+                ['key' => 'support_email',               'value' => $request->support_email,                                     'created_at' => $now, 'updated_at' => $now],
             ], ['key'], ['value', 'updated_at']);
 
             // Airline

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -12,9 +12,35 @@ class Setting extends Model
 
     protected $fillable = ['key', 'value'];
 
+    /**
+     * Default values for every known instance setting. Used to render the
+     * settings page and to backfill keys that predate a new setting, so
+     * callers never have to hardcode defaults across the codebase.
+     */
+    public static function defaults(): array
+    {
+        return [
+            'app_name'                    => config('app.name', 'YAAMS'),
+            'allow_user_airline_creation' => '0',
+            'allow_registration'          => '1',
+            'support_email'               => null,
+        ];
+    }
+
     public static function get(string $key, mixed $default = null): mixed
     {
         $row = static::find($key);
-        return $row ? $row->value : $default;
+
+        if ($row) {
+            return $row->value;
+        }
+
+        // Fall back to the declared default before the caller-supplied one.
+        return $default ?? (static::defaults()[$key] ?? null);
+    }
+
+    public static function set(string $key, mixed $value): void
+    {
+        static::updateOrCreate(['key' => $key], ['value' => $value]);
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -16,10 +16,13 @@ use App\Actions\Fortify\ResetUserPassword;
 use App\Actions\Fortify\UpdateUserPassword;
 use App\Actions\Fortify\UpdateUserProfileInformation;
 use App\Actions\Fortify\SetActiveAirline;
+use App\Models\Setting;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\View;
 use Illuminate\Support\Str;
 
 class AppServiceProvider extends ServiceProvider
@@ -37,6 +40,13 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        // Expose the instance name to every view (brand + page title). Guarded
+        // with hasTable so `artisan migrate` / fresh installs (before the
+        // settings table exists) don't blow up.
+        View::share('instanceName', Schema::hasTable('settings')
+            ? Setting::get('app_name', config('app.name'))
+            : config('app.name'));
+
         // Fortify rate limiters — referenced by config('fortify.limiters'),
         // which makes Fortify attach throttle:login / throttle:two-factor
         // middleware to its routes. Without these definitions the throttle
@@ -57,6 +67,12 @@ class AppServiceProvider extends ServiceProvider
         });
 
         Fortify::registerView(function () {
+            // Honour the instance-wide registration toggle (settings table).
+            if (Setting::get('allow_registration', '1') !== '1') {
+                return redirect()->route('login')
+                    ->with('status', 'Registration is currently closed on this instance.');
+            }
+
             return view('auth.register');
         });
 

--- a/resources/views/admin/_sidebar.blade.php
+++ b/resources/views/admin/_sidebar.blade.php
@@ -1,0 +1,25 @@
+{{-- Admin sections sidebar. Pass $active ('overview' | 'instance') to highlight
+     the current section. Users/Airlines management are not built yet. --}}
+@php($active = $active ?? 'overview')
+<div class="col-12 col-lg-3">
+    <div class="card">
+        <div class="list-group list-group-flush">
+            <a href="{{ route('admin.dashboard') }}"
+               class="list-group-item list-group-item-action {{ $active === 'overview' ? 'active' : '' }}">
+                <i class="bi bi-speedometer2 me-2"></i> Overview
+            </a>
+            <span class="list-group-item d-flex justify-content-between align-items-center text-muted">
+                <span><i class="bi bi-people me-2"></i> Users</span>
+                <span class="badge bg-secondary-subtle text-secondary">Soon</span>
+            </span>
+            <span class="list-group-item d-flex justify-content-between align-items-center text-muted">
+                <span><i class="bi bi-buildings me-2"></i> Airlines</span>
+                <span class="badge bg-secondary-subtle text-secondary">Soon</span>
+            </span>
+            <a href="{{ route('admin.settings.edit') }}"
+               class="list-group-item list-group-item-action {{ $active === 'instance' ? 'active' : '' }}">
+                <i class="bi bi-gear me-2"></i> Instance
+            </a>
+        </div>
+    </div>
+</div>

--- a/resources/views/admin/index.blade.php
+++ b/resources/views/admin/index.blade.php
@@ -10,28 +10,8 @@
 </div>
 
 <div class="row g-4">
-    {{-- Sidebar: admin sections (foundation — sections fill in over time) --}}
-    <div class="col-12 col-lg-3">
-        <div class="card">
-            <div class="list-group list-group-flush">
-                <a href="{{ route('admin.dashboard') }}" class="list-group-item list-group-item-action active">
-                    <i class="bi bi-speedometer2 me-2"></i> Overview
-                </a>
-                <span class="list-group-item d-flex justify-content-between align-items-center text-muted">
-                    <span><i class="bi bi-people me-2"></i> Users</span>
-                    <span class="badge bg-secondary-subtle text-secondary">Soon</span>
-                </span>
-                <span class="list-group-item d-flex justify-content-between align-items-center text-muted">
-                    <span><i class="bi bi-buildings me-2"></i> Airlines</span>
-                    <span class="badge bg-secondary-subtle text-secondary">Soon</span>
-                </span>
-                <span class="list-group-item d-flex justify-content-between align-items-center text-muted">
-                    <span><i class="bi bi-gear me-2"></i> Instance</span>
-                    <span class="badge bg-secondary-subtle text-secondary">Soon</span>
-                </span>
-            </div>
-        </div>
-    </div>
+    {{-- Sidebar: admin sections --}}
+    @include('admin._sidebar', ['active' => 'overview'])
 
     {{-- Main: overview --}}
     <div class="col-12 col-lg-9">
@@ -72,38 +52,127 @@
                     </div>
                 </div>
             </div>
+            <div class="col-6 col-md-3">
+                <div class="card h-100">
+                    <div class="card-body text-center">
+                        <i class="bi bi-hourglass-split fs-2 text-warning"></i>
+                        <div class="fs-3 fw-bold mt-2">{{ $stats['pendingPireps'] }}</div>
+                        <div class="text-muted small">Pending PIREPs</div>
+                    </div>
+                </div>
+            </div>
+            <div class="col-6 col-md-3">
+                <div class="card h-100">
+                    <div class="card-body text-center">
+                        <i class="bi bi-check2-circle fs-2 text-success"></i>
+                        <div class="fs-3 fw-bold mt-2">{{ $stats['acceptedFlights'] }}</div>
+                        <div class="text-muted small">Accepted Flights</div>
+                    </div>
+                </div>
+            </div>
         </div>
 
+        {{-- Instance info summary --}}
         <div class="card mt-4">
-            <div class="card-header">
-                <i class="bi bi-person-plus me-2"></i> Recently registered users
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <span><i class="bi bi-gear me-2"></i> Instance configuration</span>
+                <a href="{{ route('admin.settings.edit') }}" class="btn btn-sm btn-outline-primary">
+                    <i class="bi bi-pencil me-1"></i> Edit settings
+                </a>
             </div>
-            <div class="table-responsive">
-                <table class="table table-hover align-middle mb-0">
-                    <thead>
-                        <tr>
-                            <th>Name</th>
-                            <th>Email</th>
-                            <th>Registered</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        @forelse ($recentUsers as $user)
-                            <tr>
-                                <td>{{ $user->name }}</td>
-                                <td>{{ $user->email }}</td>
-                                <td>
-                                    {{ $user->created_at->format('Y-m-d H:i') }}
-                                    <span class="text-muted small">({{ $user->created_at->diffForHumans() }})</span>
-                                </td>
-                            </tr>
-                        @empty
-                            <tr>
-                                <td colspan="3" class="text-center text-muted">No users registered yet.</td>
-                            </tr>
-                        @endforelse
-                    </tbody>
-                </table>
+            <ul class="list-group list-group-flush">
+                <li class="list-group-item d-flex justify-content-between align-items-center">
+                    <span class="text-muted">Instance name</span>
+                    <span class="fw-semibold">{{ $instance['app_name'] }}</span>
+                </li>
+                <li class="list-group-item d-flex justify-content-between align-items-center">
+                    <span class="text-muted">Public registration</span>
+                    @if($instance['allow_registration'])
+                        <span class="badge bg-success-subtle text-success">Open</span>
+                    @else
+                        <span class="badge bg-danger-subtle text-danger">Closed</span>
+                    @endif
+                </li>
+                <li class="list-group-item d-flex justify-content-between align-items-center">
+                    <span class="text-muted">Who can found airlines</span>
+                    <span class="fw-semibold">{{ $instance['allow_user_airline_creation'] ? 'Any registered user' : 'Admins only' }}</span>
+                </li>
+                <li class="list-group-item d-flex justify-content-between align-items-center">
+                    <span class="text-muted">Support email</span>
+                    <span class="fw-semibold">{{ $instance['support_email'] ?: '—' }}</span>
+                </li>
+            </ul>
+        </div>
+
+        <div class="row g-4 mt-0">
+            {{-- Recently registered users --}}
+            <div class="col-12 col-xl-6">
+                <div class="card h-100">
+                    <div class="card-header">
+                        <i class="bi bi-person-plus me-2"></i> Recently registered users
+                    </div>
+                    <div class="table-responsive">
+                        <table class="table table-hover align-middle mb-0">
+                            <thead>
+                                <tr>
+                                    <th>Name</th>
+                                    <th>Email</th>
+                                    <th>Registered</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @forelse ($recentUsers as $user)
+                                    <tr>
+                                        <td>{{ $user->name }}</td>
+                                        <td>{{ $user->email }}</td>
+                                        <td>
+                                            <span class="text-muted small">{{ $user->created_at->diffForHumans() }}</span>
+                                        </td>
+                                    </tr>
+                                @empty
+                                    <tr>
+                                        <td colspan="3" class="text-center text-muted">No users registered yet.</td>
+                                    </tr>
+                                @endforelse
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+
+            {{-- Recently founded airlines --}}
+            <div class="col-12 col-xl-6">
+                <div class="card h-100">
+                    <div class="card-header">
+                        <i class="bi bi-buildings me-2"></i> Recently founded airlines
+                    </div>
+                    <div class="table-responsive">
+                        <table class="table table-hover align-middle mb-0">
+                            <thead>
+                                <tr>
+                                    <th>Name</th>
+                                    <th>ICAO</th>
+                                    <th>Founded</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @forelse ($recentAirlines as $airline)
+                                    <tr>
+                                        <td>{{ $airline->name }}</td>
+                                        <td>{{ $airline->icao_callsign }}</td>
+                                        <td>
+                                            <span class="text-muted small">{{ $airline->created_at->diffForHumans() }}</span>
+                                        </td>
+                                    </tr>
+                                @empty
+                                    <tr>
+                                        <td colspan="3" class="text-center text-muted">No airlines yet.</td>
+                                    </tr>
+                                @endforelse
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/resources/views/admin/settings.blade.php
+++ b/resources/views/admin/settings.blade.php
@@ -1,0 +1,119 @@
+@extends('layouts.app')
+@section('title', 'YAAMS: Instance Settings')
+
+@section('content')
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <div>
+        <h1 class="h3 mb-1"><i class="bi bi-gear me-2"></i> Instance Settings</h1>
+        <p class="text-muted mb-0">Configure instance-wide options for this YAAMS install.</p>
+    </div>
+</div>
+
+<div class="row g-4">
+    {{-- Sidebar: admin sections --}}
+    @include('admin._sidebar', ['active' => 'instance'])
+
+    {{-- Main: settings form --}}
+    <div class="col-12 col-lg-9">
+        @if (session('status'))
+            <div class="alert alert-success d-flex align-items-center">
+                <i class="bi bi-check-circle-fill me-2"></i> {{ session('status') }}
+            </div>
+        @endif
+
+        @if ($errors->any())
+            <div class="alert alert-danger">
+                <ul class="mb-0 ps-3">
+                    @foreach ($errors->all() as $error)
+                        <li>{{ $error }}</li>
+                    @endforeach
+                </ul>
+            </div>
+        @endif
+
+        <div class="card">
+            <div class="card-body p-4">
+                <form action="{{ route('admin.settings.update') }}" method="post">
+                    @csrf
+                    @method('PUT')
+
+                    {{-- General --}}
+                    <h6 class="fw-semibold mb-3"><i class="bi bi-globe2 me-2 text-primary"></i> General</h6>
+
+                    <div class="mb-4">
+                        <label for="app_name" class="form-label">Instance name</label>
+                        <div class="input-group">
+                            <span class="input-group-text"><i class="bi bi-tag text-secondary"></i></span>
+                            <input type="text"
+                                   id="app_name"
+                                   name="app_name"
+                                   class="form-control @error('app_name') is-invalid @enderror"
+                                   value="{{ old('app_name', $settings['app_name']) }}"
+                                   required>
+                        </div>
+                        <div class="form-text">Shown in the page title and header across the app.</div>
+                    </div>
+
+                    <div class="mb-4">
+                        <label for="support_email" class="form-label">Support email <span class="text-muted fw-normal">(optional)</span></label>
+                        <div class="input-group">
+                            <span class="input-group-text"><i class="bi bi-envelope text-secondary"></i></span>
+                            <input type="email"
+                                   id="support_email"
+                                   name="support_email"
+                                   class="form-control @error('support_email') is-invalid @enderror"
+                                   placeholder="support@example.com"
+                                   value="{{ old('support_email', $settings['support_email']) }}">
+                        </div>
+                        <div class="form-text">Displayed in the site footer as a contact link when set.</div>
+                    </div>
+
+                    {{-- Policies --}}
+                    <hr class="my-4">
+                    <h6 class="fw-semibold mb-3"><i class="bi bi-shield-check me-2 text-info"></i> Policies</h6>
+
+                    <div class="mb-4">
+                        <label class="form-label d-block">Public registration</label>
+                        <div class="btn-group w-100" role="group">
+                            <input type="radio" class="btn-check" name="allow_registration" id="registration_open" value="1"
+                                   {{ old('allow_registration', $settings['allow_registration']) === '1' ? 'checked' : '' }}>
+                            <label class="btn btn-outline-secondary" for="registration_open">
+                                <i class="bi bi-door-open me-1"></i> Open
+                            </label>
+
+                            <input type="radio" class="btn-check" name="allow_registration" id="registration_closed" value="0"
+                                   {{ old('allow_registration', $settings['allow_registration']) === '0' ? 'checked' : '' }}>
+                            <label class="btn btn-outline-secondary" for="registration_closed">
+                                <i class="bi bi-door-closed me-1"></i> Closed
+                            </label>
+                        </div>
+                        <div class="form-text">When closed, new users cannot self-register.</div>
+                    </div>
+
+                    <div class="mb-4">
+                        <label class="form-label d-block">Who can found new airlines?</label>
+                        <div class="btn-group w-100" role="group">
+                            <input type="radio" class="btn-check" name="allow_user_airline_creation" id="airline_creation_admin" value="0"
+                                   {{ old('allow_user_airline_creation', $settings['allow_user_airline_creation']) === '0' ? 'checked' : '' }}>
+                            <label class="btn btn-outline-secondary" for="airline_creation_admin">
+                                <i class="bi bi-person-lock me-1"></i> Admins only
+                            </label>
+
+                            <input type="radio" class="btn-check" name="allow_user_airline_creation" id="airline_creation_all" value="1"
+                                   {{ old('allow_user_airline_creation', $settings['allow_user_airline_creation']) === '1' ? 'checked' : '' }}>
+                            <label class="btn btn-outline-secondary" for="airline_creation_all">
+                                <i class="bi bi-people me-1"></i> Any registered user
+                            </label>
+                        </div>
+                        <div class="form-text">Admins can always create airlines regardless of this setting.</div>
+                    </div>
+
+                    <button class="btn btn-primary" type="submit">
+                        <i class="bi bi-check2-circle me-2"></i> Save settings
+                    </button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -59,9 +59,11 @@
                 Forgot password?
             </a>
 
-            <div class="text-center mt-4 pt-3 border-top">
-                <p class="mb-0 text-muted small">New pilot? <a href="{{ route('register') }}" class="text-primary fw-semibold text-decoration-none">Register here</a></p>
-            </div>
+            @if(\App\Models\Setting::get('allow_registration', '1') === '1')
+                <div class="text-center mt-4 pt-3 border-top">
+                    <p class="mb-0 text-muted small">New pilot? <a href="{{ route('register') }}" class="text-primary fw-semibold text-decoration-none">Register here</a></p>
+                </div>
+            @endif
         </form>
     </div>
 </div>

--- a/resources/views/home/index.blade.php
+++ b/resources/views/home/index.blade.php
@@ -20,9 +20,11 @@
     </p>
     @guest
     <div class="d-flex gap-2 flex-wrap">
+        @if(\App\Models\Setting::get('allow_registration', '1') === '1')
         <a href="{{ route('register') }}" class="btn btn-primary btn-lg px-4">
             <i class="bi bi-person-plus me-2"></i>Create an Account
         </a>
+        @endif
         <a href="{{ route('login') }}" class="btn btn-outline-secondary btn-lg px-4">
             <i class="bi bi-box-arrow-in-right me-2"></i>Sign In
         </a>
@@ -189,9 +191,11 @@
             <p class="mb-0 text-white-50 small">Create a free account and start filing PIREPs today.</p>
         </div>
         <div class="d-flex gap-2 flex-shrink-0">
+            @if(\App\Models\Setting::get('allow_registration', '1') === '1')
             <a href="{{ route('register') }}" class="btn btn-primary px-4">
                 <i class="bi bi-person-plus me-2"></i>Sign Up Free
             </a>
+            @endif
             <a href="{{ route('login') }}" class="btn btn-outline-light px-4">Sign In</a>
         </div>
     </div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <title>@yield('title', 'YAAMS')</title>
+    <title>@yield('title', $instanceName)</title>
 
     <link rel="icon" href="{{ asset('favicon.ico') }}">
 
@@ -53,8 +53,8 @@
     <header class="navbar navbar-expand-lg navbar-dark bg-dark">
         <div class="container">
                 <a class="navbar-brand d-flex align-items-center gap-2" href="{{ auth()->check() ? route('dashboard') : route('home') }}">
-                    <img src="{{ asset('img/yaams-temp-logo.png') }}" alt="YAAMS Logo" height="32">
-                <span class="fs-5 fw-bold tracking-tight">YAAMS</span>
+                    <img src="{{ asset('img/yaams-temp-logo.png') }}" alt="{{ $instanceName }} Logo" height="32">
+                <span class="fs-5 fw-bold tracking-tight">{{ $instanceName }}</span>
             </a>
 
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
@@ -148,10 +148,10 @@
                                     <li><a class="dropdown-item" href="{{ route('invitecodes.index') }}"><i class="bi bi-ticket-perforated me-2 text-secondary"></i> Invite Codes</a></li>
                                 @endif
                                 <li><a class="dropdown-item" href="{{ route('portal') }}"><i class="bi bi-buildings me-2 text-secondary"></i> Airline Portal</a></li>
-                                <li><a class="dropdown-item" href="#"><i class="bi bi-gear me-2 text-secondary"></i> Settings</a></li>
                                 @role('Super-Admin')
                                     <li><hr class="dropdown-divider"></li>
                                     <li><a class="dropdown-item" href="{{ route('admin.dashboard') }}"><i class="bi bi-shield-lock me-2 text-secondary"></i> Administration</a></li>
+                                    <li><a class="dropdown-item" href="{{ route('admin.settings.edit') }}"><i class="bi bi-gear me-2 text-secondary"></i> Instance Settings</a></li>
                                 @endrole
                                 <li><hr class="dropdown-divider"></li>
                                 <li>
@@ -174,8 +174,14 @@
 
     <footer class="bg-white border-top mt-auto py-4">
         <div class="container d-flex justify-content-between align-items-center text-muted">
-            <small>&copy; {{ date('Y') }} YAAMS Virtual Airline Management</small>
-            <small>v0.0.1 | <a href="https://www.github.com/flymia/YAAMS/" target="_blank" class="text-decoration-none text-secondary"><i class="bi bi-github"></i> GitHub</a></small>
+            <small>&copy; {{ date('Y') }} {{ $instanceName }} Virtual Airline Management</small>
+            <small>
+                @php($supportEmail = \App\Models\Setting::get('support_email'))
+                @if($supportEmail)
+                    <a href="mailto:{{ $supportEmail }}" class="text-decoration-none text-secondary"><i class="bi bi-envelope"></i> Contact</a> |
+                @endif
+                v0.0.1 | <a href="https://www.github.com/flymia/YAAMS/" target="_blank" class="text-decoration-none text-secondary"><i class="bi bi-github"></i> GitHub</a>
+            </small>
         </div>
     </footer>
 

--- a/resources/views/setup/index.blade.php
+++ b/resources/views/setup/index.blade.php
@@ -260,6 +260,40 @@
                 <div class="form-text">Admins can always create airlines regardless of this setting.</div>
             </div>
 
+            <div class="mb-3">
+                <label class="form-label d-block">Public registration</label>
+                <div class="btn-group w-100" role="group">
+                    <input type="radio" class="btn-check" name="allow_registration" id="registration_open" value="1"
+                           {{ old('allow_registration', '1') === '1' ? 'checked' : '' }}>
+                    <label class="btn btn-outline-secondary" for="registration_open">
+                        <i class="bi bi-door-open me-1"></i> Open
+                    </label>
+
+                    <input type="radio" class="btn-check" name="allow_registration" id="registration_closed" value="0"
+                           {{ old('allow_registration') === '0' ? 'checked' : '' }}>
+                    <label class="btn btn-outline-secondary" for="registration_closed">
+                        <i class="bi bi-door-closed me-1"></i> Closed
+                    </label>
+                </div>
+                <div class="form-text">When closed, new users cannot self-register.</div>
+            </div>
+
+            <div class="mb-3">
+                <label for="support_email" class="form-label">Support email <span class="text-muted fw-normal">(optional)</span></label>
+                <div class="input-group">
+                    <span class="input-group-text"><i class="bi bi-envelope text-secondary"></i></span>
+                    <input type="email"
+                           id="support_email"
+                           name="support_email"
+                           class="form-control @error('support_email') is-invalid @enderror"
+                           placeholder="support@example.com"
+                           value="{{ old('support_email') }}">
+                </div>
+                @error('support_email')
+                    <div class="invalid-feedback d-block mt-1">{{ $message }}</div>
+                @enderror
+            </div>
+
             {{-- Section 4: Admin account --}}
             <div class="step-divider">
                 <span class="section-icon bg-warning bg-opacity-10 text-warning">

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,6 +13,7 @@ use App\Http\Controllers\PortalController;
 use App\Http\Controllers\InviteCodeController;
 use App\Http\Controllers\AirlineController;
 use App\Http\Controllers\Admin\AdminController;
+use App\Http\Controllers\Admin\SettingsController;
 
 // Setup wizard — only accessible before any user exists
 Route::get('/setup', [SetupController::class, 'show'])->name('setup.index');
@@ -52,6 +53,10 @@ Route::middleware(['auth'])->group(function () {
     // -------------------------------------------------------------------------
     Route::prefix('admin')->name('admin.')->middleware('role:Super-Admin')->group(function () {
         Route::get('/', [AdminController::class, 'index'])->name('dashboard');
+
+        // Instance settings — edit the key/value rows in the `settings` table
+        Route::get('/settings', [SettingsController::class, 'edit'])->name('settings.edit');
+        Route::put('/settings', [SettingsController::class, 'update'])->name('settings.update');
     });
 
     // Dashboard — no airline middleware; controller handles the redirect to /portal itself


### PR DESCRIPTION
- Add /admin/settings (Super-Admin) to edit all settings-table values via new Admin\SettingsController + admin/settings.blade.php
- Setting model: add set() writer and defaults() fallback map
- New settings: allow_registration (gates self-registration at view, submit, and Register links) and support_email (footer contact link)
- Wire app_name to actually display (navbar brand, page title, footer) via View::share('instanceName') in AppServiceProvider
- Admin overview: pending-PIREP + accepted-flight stats, instance config summary, recent-airlines table; extract admin/_sidebar partial
- Point navbar "Settings" link at instance settings (Super-Admin only)
- Sync new settings into the /setup wizard (controller + view)