### PR TITLE
Fix mail queue so slow/failing SMTP can't block PIREP filing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,9 @@ DB_PASSWORD=
 
 BROADCAST_DRIVER=log
 CACHE_DRIVER=file
-QUEUE_CONNECTION=sync
+# Background queue for outgoing mail. `database` reuses the app DB and requires
+# a running worker (`php artisan queue:work`). Set to `redis` to use Redis.
+QUEUE_CONNECTION=database
 SESSION_DRIVER=file
 SESSION_LIFETIME=120
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,7 @@ Notifications use Laravel's native notification system so delivery channels are 
 
 - **`database`** is Laravel's built-in channel. It persists to the standard `notifications` table (uuid PK, polymorphic `notifiable`, JSON `data`, `read_at`) via `Illuminate\Notifications\DatabaseNotification`. A notification opts in by returning `'database'` from `via()` and implementing `toArray($notifiable): array` (`title`, `message`, optional `url`) — the payload is stored in `data`. The bell/list UI reads unread rows through the `Notifiable` trait's `unreadNotifications` relation; `User::countNewNotifications()` wraps `unreadNotifications()->count()`. Dismissing a notification calls `$notification->markAsRead()`.
 - **`mail`** is Laravel's built-in channel; `toMail()` returns a `MailMessage`.
-- Notification classes implement `ShouldQueue`, so mail dispatches inline under `QUEUE_CONNECTION=sync` and becomes async automatically once a real queue is configured.
+- Notification classes implement `ShouldQueue`, and use the `App\Notifications\Concerns\QueuesMailChannel` trait. The trait's `viaConnections()` pins the `database` channel to the `sync` connection (so the in-app/bell notification is written immediately, with no worker needed) while the `mail` channel falls through to the default queue connection (`QUEUE_CONNECTION`, `database` by default). A slow or failing SMTP server therefore never blocks or fails the triggering PIREP request — the email is delivered by the background worker. Any new PIREP notification should `use QueuesMailChannel` for the same guarantee.
 
 **To add a channel** (e.g. webhook): add a channel class + `Notification::extend('webhook', ...)`, add `'webhook'` to `via()`, and add a `toWebhook()` renderer. No event/listener changes. `via()` receives `$notifiable`, so per-user channel preferences live there — the `mail` channel is already gated on the recipient's `email_notifications` preference.
 
@@ -127,6 +127,23 @@ API tokens are printed during `php artisan migrate --seed`.
 
 Key `.env` values beyond standard Laravel:
 - `FLIGHT_PAGE_LIMIT` — number of flights per page in the pilot flight list (default: 10)
+- `QUEUE_CONNECTION` — background job backend (default: `database`; set to `redis` to use Redis). Notification email is dispatched on this queue, so a worker must be running in every environment where mail should actually be sent — see below.
+
+### Queue / Background Jobs
+
+Outgoing notification email is queued (see the Notifications section) so a slow/failing SMTP server can never block PIREP filing/review. This requires a worker to drain the queue:
+
+- **Dev:** `docker exec yaams-dev-app php artisan queue:work` (mail lands in smtp4dev at http://localhost:8081). Without a running worker, in-app notifications still appear instantly but no email is sent.
+- **Production:** run `php artisan queue:work --tries=3` under a process supervisor so it restarts on exit, e.g. a Supervisor program:
+  ```ini
+  [program:yaams-worker]
+  command=php /app/artisan queue:work --tries=3 --sleep=3
+  autostart=true
+  autorestart=true
+  numprocs=1
+  ```
+  Run `php artisan queue:restart` on each deploy so workers pick up new code. Failed sends are recorded in the `failed_jobs` table; inspect with `php artisan queue:failed` and requeue with `php artisan queue:retry`.
+- The `database` driver uses the `jobs`/`job_batches` tables created by migration (`failed_jobs` already existed). Switching to Redis is a pure `QUEUE_CONNECTION` change — no code change, since only the in-app channel is pinned to `sync`.
 
 Docker setup lives in `Docker/` with `Dockerfile` and `docker-compose.yml`. A Nix flake (`flake.nix`) is also provided for NixOS environments.
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ An decentralised open-source virtual airline management platform. Track PIREPs, 
    php artisan key:generate
    php artisan migrate --seed
    ```
+4. In a separate shell, start the queue worker so notification emails are
+   delivered (they are queued so a slow/failing SMTP can't block PIREP filing):
+   ```bash
+   docker exec yaams-dev-app php artisan queue:work
+   ```
+   Sent mail is viewable in smtp4dev at http://localhost:8081.
 
 ### Native Setup
 1. Ensure PHP 8.2+, Composer, and a MariaDB/MySQL database are installed.

--- a/app/Notifications/Concerns/QueuesMailChannel.php
+++ b/app/Notifications/Concerns/QueuesMailChannel.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Notifications\Concerns;
+
+/**
+ * Keeps the in-app (`database`) notification channel synchronous while letting
+ * the `mail` channel be queued.
+ *
+ * The notification implements `ShouldQueue`, so by default every channel would
+ * be pushed onto the queue. Pinning `database` to the `sync` connection means
+ * the bell/in-app notification is written immediately (instant, no worker
+ * required), while `mail` falls through to the app's default queue connection
+ * (`database`, or `redis` via `QUEUE_CONNECTION`). A slow or failing SMTP server
+ * therefore never blocks or fails the triggering web/API request.
+ */
+trait QueuesMailChannel
+{
+    /**
+     * Per-channel queue connections.
+     *
+     * @return array<string, string>
+     */
+    public function viaConnections(): array
+    {
+        return ['database' => 'sync'];
+    }
+}

--- a/app/Notifications/PirepAccepted.php
+++ b/app/Notifications/PirepAccepted.php
@@ -3,6 +3,7 @@
 namespace App\Notifications;
 
 use App\Models\Flight;
+use App\Notifications\Concerns\QueuesMailChannel;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
@@ -18,6 +19,7 @@ use Illuminate\Notifications\Notification;
 class PirepAccepted extends Notification implements ShouldQueue
 {
     use Queueable;
+    use QueuesMailChannel;
 
     public function __construct(public Flight $flight)
     {

--- a/app/Notifications/PirepFiled.php
+++ b/app/Notifications/PirepFiled.php
@@ -3,6 +3,7 @@
 namespace App\Notifications;
 
 use App\Models\Flight;
+use App\Notifications\Concerns\QueuesMailChannel;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
@@ -19,6 +20,7 @@ use Illuminate\Notifications\Notification;
 class PirepFiled extends Notification implements ShouldQueue
 {
     use Queueable;
+    use QueuesMailChannel;
 
     public function __construct(public Flight $flight)
     {

--- a/app/Notifications/PirepRejected.php
+++ b/app/Notifications/PirepRejected.php
@@ -3,6 +3,7 @@
 namespace App\Notifications;
 
 use App\Models\Flight;
+use App\Notifications\Concerns\QueuesMailChannel;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
@@ -18,6 +19,7 @@ use Illuminate\Notifications\Notification;
 class PirepRejected extends Notification implements ShouldQueue
 {
     use Queueable;
+    use QueuesMailChannel;
 
     public function __construct(public Flight $flight)
     {

--- a/database/migrations/2026_07_04_231119_create_jobs_table.php
+++ b/database/migrations/2026_07_04_231119_create_jobs_table.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Tables required by the `database` queue driver. `failed_jobs` already exists
+ * (see 2019_08_19_000000_create_failed_jobs_table), so it is not recreated here.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('jobs')) {
+            Schema::create('jobs', function (Blueprint $table) {
+                $table->id();
+                $table->string('queue')->index();
+                $table->longText('payload');
+                $table->unsignedTinyInteger('attempts');
+                $table->unsignedInteger('reserved_at')->nullable();
+                $table->unsignedInteger('available_at');
+                $table->unsignedInteger('created_at');
+            });
+        }
+
+        if (! Schema::hasTable('job_batches')) {
+            Schema::create('job_batches', function (Blueprint $table) {
+                $table->string('id')->primary();
+                $table->string('name');
+                $table->integer('total_jobs');
+                $table->integer('pending_jobs');
+                $table->integer('failed_jobs');
+                $table->longText('failed_job_ids');
+                $table->mediumText('options')->nullable();
+                $table->integer('cancelled_at')->nullable();
+                $table->integer('created_at');
+                $table->integer('finished_at')->nullable();
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('jobs');
+        Schema::dropIfExists('job_batches');
+    }
+};


### PR DESCRIPTION
- Queue the notification mail channel; keep in-app (database) channel sync
- Add QueuesMailChannel trait (viaConnections pins database => sync)
- Apply trait to PirepFiled, PirepAccepted, PirepRejected
- Add jobs/job_batches migration for the database queue driver
- Default QUEUE_CONNECTION to database (swappable to redis via env)
- Document queue setup, worker command, and Supervisor snippet in CLAUDE.md
- Add dev queue:work step to README