### PR TITLE
Feature: Implemented prometheus metrics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,10 @@ QUEUE_CONNECTION=database
 SESSION_DRIVER=file
 SESSION_LIFETIME=120
 
+# Bearer token required to scrape the Prometheus /metrics endpoint.
+# Leave unset to disable the endpoint entirely.
+METRICS_TOKEN=
+
 MEMCACHED_HOST=127.0.0.1
 
 REDIS_HOST=127.0.0.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,6 +177,16 @@ The `/api/v1` REST API is documented with [Scribe](https://scribe.knuckles.wtf) 
   - **Production** — baked into the image at build time: `Docker/Dockerfile.prod` runs `scribe:generate` in a dedicated `docs` stage (which installs the dev deps that carry Scribe) and `COPY --from=docs`es `public/docs` into the Scribe-free runtime image. nginx serves it statically (`index index.php index.html` in `Docker/nginx.conf` resolves `/docs` → `public/docs/index.html`). No deploy step needed.
   - **Dev** — the one-shot `docs` service in `Docker/docker-compose.yml` runs `scribe:generate` into the mounted repo before `app` serves; `php artisan serve` serves the static files, and `routes/web.php` has a `Route::redirect('/docs', '/docs/index.html')` so `/docs` resolves (the built-in dev server won't auto-serve a directory index). Regenerate manually with `docker exec yaams-dev-app php artisan scribe:generate` after editing annotations.
 
+### Prometheus Metrics
+
+Instance monitoring endpoint at `/metrics` (`spatie/laravel-prometheus`), returning domain gauges in Prometheus text format with the `yaams_` namespace prefix:
+
+- **Scrape-time evaluation** — every gauge is a closure in `app/Providers/PrometheusServiceProvider.php`, executed fresh on each scrape as a cheap aggregate DB query. There is no cross-request metric storage (`config/prometheus.php` keeps `'cache' => null`), so no APCu/Redis is needed. HTTP request counters/histograms are intentionally out of scope — they would require shared FPM storage and are better harvested at the reverse-proxy layer.
+- **Gauges** — users, airlines, flights by review status (`status` label mapped from the hardcoded flight status IDs), aircraft by lifecycle status, unused invite codes, failed jobs, plus the package's `QueueSizeCollector` (queue depth via `Queue::size()`).
+- **Auth** — `App\Http\Middleware\MetricsAuth` (wired via the `middleware` key in `config/prometheus.php`) requires `Authorization: Bearer $METRICS_TOKEN`; when `METRICS_TOKEN` is unset, the endpoint always returns 403. The token is env-level ops config (`services.metrics.token` in `config/services.php`), deliberately **not** a `Setting` row — it belongs to the scraper's infrastructure, so it gets no setup-wizard/admin-settings wiring.
+- **Adding a gauge** — chain `Prometheus::addGauge('Label')->name('snake_name')->helpText(...)->value(fn () => ...)` in `PrometheusServiceProvider::register()`; labeled gauges return `[[value, [labelValue]], ...]` from the closure. Keep every closure a single cheap aggregate query.
+- Scribe API docs are unaffected (Scribe only matches `api/*` routes).
+
 ### Key Model Relationships
 
 - `Aircraft::used_by` — FK to `airlines.id` (not `airline_id`)
@@ -200,6 +210,7 @@ Key `.env` values beyond standard Laravel:
 - `FLIGHT_PAGE_LIMIT` — number of flights per page in the pilot flight list (default: 10)
 - `QUEUE_CONNECTION` — background job backend (default: `database`; set to `redis` to use Redis). Notification email is dispatched on this queue, so a worker must be running in every environment where mail should actually be sent — see below.
 - `ACTIVITYLOG_RETENTION_DAYS` — how long activity-log rows are kept before `activitylog:clean` prunes them (default: `180`). Requires the scheduler to be running — see below.
+- `METRICS_TOKEN` — bearer token required to scrape the Prometheus `/metrics` endpoint (see Prometheus Metrics). Unset (default) disables the endpoint.
 
 ### Queue / Background Jobs
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A decentralised, open-source virtual airline management platform. Track PIREPs, 
 - [Quick Start](#quick-start-development)
 - [Running the Tests](#running-the-tests)
 - [API](#api)
+- [Monitoring](#monitoring)
 - [Production Deployment](#production-deployment)
 - [Contributing](#contributing)
 - [License](#license)
@@ -34,6 +35,7 @@ A decentralised, open-source virtual airline management platform. Track PIREPs, 
 - **Multi-airline** - belong to several airlines and switch between them
 - **Notifications** - in-app and email delivery
 - **Activity log** - audit trail with a configurable verbosity level
+- **Prometheus metrics** - live domain gauges at `/metrics` for monitoring
 - **REST API (v1)** - for custom ACARS clients and integrations
 
 ## Tech Stack
@@ -100,6 +102,21 @@ The PHPUnit suite (`tests/`) covers the core domain rules - location continuity,
 ## API
 
 YAAMS ships a JSON REST API under `/api/v1`, authenticated with Sanctum bearer tokens - built for custom ACARS clients and integrations. Interactive documentation (generated with [Scribe](https://scribe.knuckles.wtf)) is served at **`/docs`**, with an OpenAPI spec at `/docs.openapi` and a Postman collection at `/docs.postman`.
+
+## Monitoring
+
+YAAMS exposes Prometheus metrics at **`/metrics`** - domain gauges (users, airlines, flights and aircraft by status, unused invite codes, queue depth, failed jobs) computed live on each scrape, so no extra storage or services are needed.
+
+The endpoint is disabled by default. To enable it, set `METRICS_TOKEN` in `.env` and scrape with it as a bearer token:
+
+```yaml
+scrape_configs:
+  - job_name: yaams
+    scheme: https
+    bearer_token: "<METRICS_TOKEN>"
+    static_configs:
+      - targets: ["your.domain"]
+```
 
 ## Production Deployment
 

--- a/app/Http/Middleware/MetricsAuth.php
+++ b/app/Http/Middleware/MetricsAuth.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class MetricsAuth
+{
+    /**
+     * Require the bearer token configured as METRICS_TOKEN (services.metrics.token).
+     * When no token is configured, the metrics endpoint is disabled entirely.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $token = config('services.metrics.token');
+
+        if (empty($token) || ! hash_equals($token, (string) $request->bearerToken())) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Providers/PrometheusServiceProvider.php
+++ b/app/Providers/PrometheusServiceProvider.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Providers;
+
+use App\Models\Aircraft;
+use App\Models\Airline;
+use App\Models\Flight;
+use App\Models\InviteCode;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\ServiceProvider;
+use Spatie\Prometheus\Collectors\Queue\QueueSizeCollector;
+use Spatie\Prometheus\Facades\Prometheus;
+
+class PrometheusServiceProvider extends ServiceProvider
+{
+    /**
+     * flights.status_id is a hardcoded FK (see CLAUDE.md "Flight Status IDs").
+     */
+    private const FLIGHT_STATUSES = [
+        1 => 'pending',
+        2 => 'accepted',
+        3 => 'rejected',
+    ];
+
+    private const AIRCRAFT_STATUSES = [
+        Aircraft::STATUS_ACTIVE,
+        Aircraft::STATUS_INACTIVE,
+        Aircraft::STATUS_RETIRED,
+    ];
+
+    /*
+     * All gauges are evaluated fresh on every scrape of /metrics, so no
+     * cross-request metric storage is involved. Keep every value() a cheap
+     * aggregate query - the endpoint runs them all on each scrape.
+     */
+    public function register(): void
+    {
+        Prometheus::addGauge('Users total')
+            ->name('users_total')
+            ->helpText('Total number of registered users')
+            ->value(fn () => User::count());
+
+        Prometheus::addGauge('Airlines total')
+            ->name('airlines_total')
+            ->helpText('Total number of airlines')
+            ->value(fn () => Airline::count());
+
+        Prometheus::addGauge('Flights total')
+            ->name('flights_total')
+            ->label('status')
+            ->helpText('Total number of filed flights (PIREPs) by review status')
+            ->value(function () {
+                $counts = Flight::query()
+                    ->toBase()
+                    ->selectRaw('status_id, count(*) as aggregate')
+                    ->groupBy('status_id')
+                    ->pluck('aggregate', 'status_id');
+
+                return collect(self::FLIGHT_STATUSES)
+                    ->map(fn (string $label, int $id) => [(int) ($counts[$id] ?? 0), [$label]])
+                    ->values()
+                    ->all();
+            });
+
+        Prometheus::addGauge('Aircraft total')
+            ->name('aircraft_total')
+            ->label('status')
+            ->helpText('Total number of aircraft by lifecycle status')
+            ->value(function () {
+                $counts = Aircraft::query()
+                    ->toBase()
+                    ->selectRaw('status, count(*) as aggregate')
+                    ->groupBy('status')
+                    ->pluck('aggregate', 'status');
+
+                return collect(self::AIRCRAFT_STATUSES)
+                    ->map(fn (string $status) => [(int) ($counts[$status] ?? 0), [$status]])
+                    ->all();
+            });
+
+        Prometheus::addGauge('Invite codes unused')
+            ->name('invite_codes_unused_total')
+            ->helpText('Number of generated invite codes not yet redeemed')
+            ->value(fn () => InviteCode::whereNull('used_by')->count());
+
+        Prometheus::addGauge('Queue failed jobs')
+            ->name('queue_failed_jobs_total')
+            ->helpText('Number of jobs in the failed_jobs table')
+            ->value(fn () => DB::table('failed_jobs')->count());
+
+        Prometheus::registerCollectorClasses([
+            QueueSizeCollector::class,
+        ]);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "laravel/tinker": "^2.10",
         "larswiegers/laravel-maps": "^0.20.0",
         "spatie/laravel-activitylog": "^4.12",
-        "spatie/laravel-permission": "^8.0"
+        "spatie/laravel-permission": "^8.0",
+        "spatie/laravel-prometheus": "^1.4"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "92aad8b15a2dd052ae9cf5aa04bb1801",
+    "content-hash": "11d518d23cce1125b206a18eb72c50b7",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -3561,6 +3561,76 @@
             "time": "2025-09-19T22:51:08+00:00"
         },
         {
+            "name": "promphp/prometheus_client_php",
+            "version": "v2.15.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PromPHP/prometheus_client_php.git",
+                "reference": "e153786bda5ca1d07335a2b5f477742c37195c40"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PromPHP/prometheus_client_php/zipball/e153786bda5ca1d07335a2b5f477742c37195c40",
+                "reference": "e153786bda5ca1d07335a2b5f477742c37195c40",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "^8.2"
+            },
+            "replace": {
+                "endclothing/prometheus_client_php": "*",
+                "jimdo/prometheus_client_php": "*",
+                "lkaemmerling/prometheus_client_php": "*"
+            },
+            "require-dev": {
+                "guzzlehttp/guzzle": "^6.3|^7.0",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^1.5.4",
+                "phpstan/phpstan-phpunit": "^1.1.0",
+                "phpstan/phpstan-strict-rules": "^1.1.0",
+                "phpunit/phpunit": "^9.4",
+                "predis/predis": "^2.3",
+                "squizlabs/php_codesniffer": "^3.6 || ^4.0",
+                "symfony/polyfill-apcu": "^1.6"
+            },
+            "suggest": {
+                "ext-apc": "Required if using APCu.",
+                "ext-pdo": "Required if using PDO.",
+                "ext-redis": "Required if using Redis.",
+                "predis/predis": "Required if using Predis.",
+                "promphp/prometheus_push_gateway_php": "An easy client for using Prometheus PushGateway.",
+                "symfony/polyfill-apcu": "Required if you use APCu."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Prometheus\\": "src/Prometheus/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Lukas Kämmerling",
+                    "email": "kontakt@lukas-kaemmerling.de"
+                }
+            ],
+            "description": "Prometheus instrumentation library for PHP applications.",
+            "support": {
+                "issues": "https://github.com/PromPHP/prometheus_client_php/issues",
+                "source": "https://github.com/PromPHP/prometheus_client_php/tree/v2.15.1"
+            },
+            "time": "2026-05-28T07:51:04+00:00"
+        },
+        {
             "name": "psr/clock",
             "version": "1.0.0",
             "source": {
@@ -4487,6 +4557,83 @@
                 }
             ],
             "time": "2026-05-30T19:30:22+00:00"
+        },
+        {
+            "name": "spatie/laravel-prometheus",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-prometheus.git",
+                "reference": "0d9b10000038a40e7b2738a31d63830c425e3be7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-prometheus/zipball/0d9b10000038a40e7b2738a31d63830c425e3be7",
+                "reference": "0d9b10000038a40e7b2738a31d63830c425e3be7",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/config": "^11.0|^12.0",
+                "illuminate/contracts": "^11.0|^12.0",
+                "illuminate/support": "^11.0|^12.0",
+                "php": "^8.3",
+                "promphp/prometheus_client_php": "^2.7.1",
+                "spatie/laravel-package-tools": "^1.15.0"
+            },
+            "require-dev": {
+                "ext-redis": "*",
+                "larastan/larastan": "^3.0",
+                "laravel/horizon": "^5.28",
+                "laravel/pint": "^1.10",
+                "mockery/mockery": "^1.6",
+                "nunomaduro/collision": "^8.0",
+                "orchestra/testbench": "^9.0|^10.0",
+                "pestphp/pest": "^3.0",
+                "pestphp/pest-plugin-arch": "^3.0",
+                "pestphp/pest-plugin-laravel": "^3.0",
+                "spatie/laravel-ray": "^1.32.4",
+                "spatie/pest-plugin-snapshots": "^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Prometheus": "Spatie\\Prometheus\\Facades\\Prometheus"
+                    },
+                    "providers": [
+                        "Spatie\\Prometheus\\PrometheusServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\Prometheus\\": "src/",
+                    "Spatie\\Prometheus\\Database\\Factories\\": "database/factories/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Export Laravel metrics to Prometheus",
+            "homepage": "https://github.com/spatie/laravel-prometheus",
+            "keywords": [
+                "laravel",
+                "laravel-prometheus",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-prometheus/issues",
+                "source": "https://github.com/spatie/laravel-prometheus/tree/1.4.0"
+            },
+            "time": "2026-01-26T07:30:13+00:00"
         },
         {
             "name": "spomky-labs/cbor-php",

--- a/config/app.php
+++ b/config/app.php
@@ -184,6 +184,7 @@ return [
         App\Providers\AppServiceProvider::class,
         App\Providers\AuthServiceProvider::class,
         // App\Providers\BroadcastServiceProvider::class,
+        App\Providers\PrometheusServiceProvider::class,
         App\Providers\EventServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
 

--- a/config/prometheus.php
+++ b/config/prometheus.php
@@ -1,0 +1,59 @@
+<?php
+
+return [
+    'enabled' => true,
+
+    /*
+     * The urls that will return metrics.
+     */
+    'urls' => [
+        'default' => 'metrics',
+    ],
+
+    /*
+     * Only these IP's will be allowed to visit the above urls.
+     * All IP's are allowed when empty.
+     */
+    'allowed_ips' => [
+        // '1.2.3.4',
+    ],
+
+    /*
+     * This is the default namespace that will be
+     * used by all metrics
+     */
+    'default_namespace' => 'yaams',
+
+    /*
+     * The middleware that will be applied to the urls above
+     */
+    'middleware' => [
+        App\Http\Middleware\MetricsAuth::class,
+    ],
+
+    /*
+     * You can override these classes to customize low-level behaviour of the package.
+     * In most cases, you can just use the defaults.
+     */
+    'actions' => [
+        'render_collectors' => Spatie\Prometheus\Actions\RenderCollectorsAction::class,
+    ],
+
+    /**
+     * Allow storage to be wiped after a render of data in metrics controller.
+     */
+    'wipe_storage_after_rendering' => false,
+
+    /**
+     * Select a cache to store gauges, counters, summaries and histograms between requests.
+     * In a multi node setup you should ensure that each node writes to its own
+     * cache instance or uses a node specific prefix.
+     * Configure the cache store in config/cache.php.
+     *
+     * to use an in memory adapter for testing use array or null as your store
+     * or remove the cache entry all together:
+     *  'cache' => null       // InMemory implementation without laravel cache
+     *  'cache' => 'array'    // InMemory implementation using laravel cache
+     */
+    'cache' => null,
+];

--- a/config/services.php
+++ b/config/services.php
@@ -30,4 +30,9 @@ return [
         'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
     ],
 
+    'metrics' => [
+        // Bearer token for the Prometheus /metrics endpoint. Unset = endpoint disabled.
+        'token' => env('METRICS_TOKEN'),
+    ],
+
 ];

--- a/tests/Feature/MetricsEndpointTest.php
+++ b/tests/Feature/MetricsEndpointTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Aircraft;
+use App\Models\Airline;
+use App\Models\Flight;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Concerns\SeedsDomain;
+use Tests\TestCase;
+
+/**
+ * The Prometheus /metrics endpoint: the bearer-token gate (METRICS_TOKEN)
+ * and the scrape-time domain gauges.
+ */
+class MetricsEndpointTest extends TestCase
+{
+    use RefreshDatabase, SeedsDomain;
+
+    private const TOKEN = 'test-metrics-token';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['services.metrics.token' => self::TOKEN]);
+    }
+
+    public function test_requests_without_a_token_are_rejected(): void
+    {
+        $this->get('/metrics')->assertForbidden();
+    }
+
+    public function test_requests_with_a_wrong_token_are_rejected(): void
+    {
+        $this->withToken('wrong-token')->get('/metrics')->assertForbidden();
+    }
+
+    public function test_the_endpoint_is_disabled_when_no_token_is_configured(): void
+    {
+        config(['services.metrics.token' => null]);
+
+        $this->get('/metrics')->assertForbidden();
+        $this->withToken('')->get('/metrics')->assertForbidden();
+    }
+
+    public function test_a_valid_token_returns_prometheus_text_format(): void
+    {
+        $response = $this->withToken(self::TOKEN)->get('/metrics');
+
+        $response->assertOk();
+        $this->assertStringContainsString('text/plain', (string) $response->headers->get('Content-Type'));
+        $response->assertSee('yaams_users_total', false);
+        $response->assertSee('yaams_airlines_total', false);
+        $response->assertSee('yaams_queue_size', false);
+    }
+
+    public function test_domain_gauges_report_current_counts(): void
+    {
+        $this->seedReferenceData();
+        $airline = Airline::factory()->create();
+        $pilot = $this->memberOf($airline, 'Pilot');
+        $aircraft = Aircraft::factory()->create([
+            'used_by' => $airline->id,
+            'status' => Aircraft::STATUS_ACTIVE,
+        ]);
+        Flight::factory()->create([
+            'airline_id' => $airline->id,
+            'aircraft_id' => $aircraft->id,
+            'pilot_id' => $pilot->id,
+            'status_id' => 1,
+        ]);
+        Flight::factory()->create([
+            'airline_id' => $airline->id,
+            'aircraft_id' => $aircraft->id,
+            'pilot_id' => $pilot->id,
+            'status_id' => 2,
+        ]);
+
+        $body = $this->withToken(self::TOKEN)->get('/metrics')->assertOk()->getContent();
+
+        $this->assertStringContainsString('yaams_users_total ' . User::count(), $body);
+        $this->assertStringContainsString('yaams_airlines_total 1', $body);
+        $this->assertStringContainsString('yaams_flights_total{status="pending"} 1', $body);
+        $this->assertStringContainsString('yaams_flights_total{status="accepted"} 1', $body);
+        $this->assertStringContainsString('yaams_flights_total{status="rejected"} 0', $body);
+        $this->assertStringContainsString('yaams_aircraft_total{status="active"} 1', $body);
+        $this->assertStringContainsString('yaams_aircraft_total{status="retired"} 0', $body);
+        $this->assertStringContainsString('yaams_queue_failed_jobs_total 0', $body);
+    }
+}


### PR DESCRIPTION
This PR fixes #77. It adds Prometheus metrics, which show instance wide stats which can be used to visualize everything on Grafana.

Example output:
```
# HELP yaams_aircraft_total Total number of aircraft by lifecycle status
# TYPE yaams_aircraft_total gauge
yaams_aircraft_total{status="active"} 2
yaams_aircraft_total{status="inactive"} 0
yaams_aircraft_total{status="retired"} 0
# HELP yaams_airlines_total Total number of airlines
# TYPE yaams_airlines_total gauge
yaams_airlines_total 2
# HELP yaams_flights_total Total number of filed flights (PIREPs) by review status
# TYPE yaams_flights_total gauge
yaams_flights_total{status="accepted"} 1
yaams_flights_total{status="pending"} 0
yaams_flights_total{status="rejected"} 0
# HELP yaams_invite_codes_unused_total Number of generated invite codes not yet redeemed
# TYPE yaams_invite_codes_unused_total gauge
yaams_invite_codes_unused_total 0
# HELP yaams_queue_failed_jobs_total Number of jobs in the failed_jobs table
# TYPE yaams_queue_failed_jobs_total gauge
yaams_queue_failed_jobs_total 0
# HELP yaams_queue_size The total number of jobs in the queue
# TYPE yaams_queue_size gauge
yaams_queue_size{connection="database",queue="default"} 0
# HELP yaams_users_total Total number of registered users
# TYPE yaams_users_total gauge
yaams_users_total 2
```

To configure it, you need to add the METRICS_TOKEN to the .env file.