### PR TITLE
Refine 2FA to enterprise-grade

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -8,6 +8,10 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\ValidationException;
+use Laravel\Fortify\Actions\ConfirmTwoFactorAuthentication;
+use Laravel\Fortify\Actions\DisableTwoFactorAuthentication;
+use Laravel\Fortify\Actions\EnableTwoFactorAuthentication;
+use Laravel\Fortify\Actions\GenerateNewRecoveryCodes;
 
 /**
  * User-facing account settings (profile, security, notification preferences).
@@ -32,7 +36,80 @@ class SettingsController extends Controller
     {
         return view('settings.security', [
             'tokens' => $request->user()->tokens()->latest()->get(),
+            // Recovery codes are shown once (right after confirming/regenerating,
+            // or after an explicit password-confirmed reveal) and hidden otherwise.
+            'revealRecoveryCodes' => (bool) $request->session()->get('reveal_recovery_codes'),
         ]);
+    }
+
+    /**
+     * Begin two-factor enrolment. Requires the account password, then generates
+     * an unconfirmed secret; the user confirms it with a TOTP code afterwards.
+     */
+    public function enableTwoFactor(Request $request, EnableTwoFactorAuthentication $enable)
+    {
+        $request->validate(['current_password' => ['required', 'current_password']]);
+
+        $enable($request->user());
+
+        return redirect()->route('settings.security');
+    }
+
+    /**
+     * Finish enrolment by verifying a TOTP code. On success the fresh recovery
+     * codes are revealed once.
+     */
+    public function confirmTwoFactor(Request $request, ConfirmTwoFactorAuthentication $confirm)
+    {
+        $request->validate(['code' => ['required', 'string']]);
+
+        $confirm($request->user(), $request->input('code'));
+
+        return redirect()
+            ->route('settings.security')
+            ->with('status', 'two-factor-authentication-confirmed')
+            ->with('reveal_recovery_codes', true);
+    }
+
+    /**
+     * Regenerate the recovery codes (password-gated) and reveal the new set once.
+     */
+    public function regenerateRecoveryCodes(Request $request, GenerateNewRecoveryCodes $generate)
+    {
+        $request->validate(['current_password' => ['required', 'current_password']]);
+
+        $generate($request->user());
+
+        return redirect()
+            ->route('settings.security')
+            ->with('status', 'recovery-codes-generated')
+            ->with('reveal_recovery_codes', true);
+    }
+
+    /**
+     * Re-display the existing recovery codes once, behind a password check.
+     */
+    public function revealRecoveryCodes(Request $request)
+    {
+        $request->validate(['current_password' => ['required', 'current_password']]);
+
+        return redirect()
+            ->route('settings.security')
+            ->with('reveal_recovery_codes', true);
+    }
+
+    /**
+     * Disable two-factor authentication (password-gated).
+     */
+    public function disableTwoFactor(Request $request, DisableTwoFactorAuthentication $disable)
+    {
+        $request->validate(['current_password' => ['required', 'current_password']]);
+
+        $disable($request->user());
+
+        return redirect()
+            ->route('settings.security')
+            ->with('status', 'two-factor-authentication-disabled');
     }
 
     public function storeToken(Request $request)

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -128,6 +128,11 @@ class AppServiceProvider extends ServiceProvider
         // second-factor code (mirrors the login page styling).
         Fortify::twoFactorChallengeView(fn () => view('auth.two-factor-challenge'));
 
+        // Password confirmation screen. The 2FA UI confirms the password inline
+        // via SettingsController, but Fortify's built-in 2FA routes are gated by
+        // confirmPassword => true and redirect here if ever hit directly.
+        Fortify::confirmPasswordView(fn () => view('auth.confirm-password'));
+
         // Die Login-Pipeline von Fortify anpassen:
         // RedirectIfTwoFactorAuthenticatable diverts users with 2FA enabled to
         // the challenge screen before the password is accepted. The active

--- a/config/fortify.php
+++ b/config/fortify.php
@@ -149,8 +149,12 @@ return [
         Features::emailVerification(),
         Features::updateProfileInformation(),
         Features::updatePasswords(),
+        // 2FA management in the UI is handled by our own password-gated
+        // SettingsController routes. confirmPassword => true additionally guards
+        // Fortify's built-in 2FA routes (which we no longer link to) so a live
+        // session cannot hit them ungated.
         Features::twoFactorAuthentication([
-            'confirmPassword' => false,
+            'confirmPassword' => true,
         ]),
     ],
 ];

--- a/resources/views/auth/confirm-password.blade.php
+++ b/resources/views/auth/confirm-password.blade.php
@@ -1,0 +1,46 @@
+@extends('layouts.loginlayout')
+@section('title', 'Confirm Password')
+@section('content')
+
+<div class="card shadow-sm">
+    <div class="card-body p-4">
+        <div class="text-center mb-4">
+            <img src="{{ asset('img/yaams-logo-icon.svg') }}" alt="YAAMS Logo" height="60" class="mb-3">
+            <h1 class="h4 mb-2 fw-bold">Confirm your password</h1>
+            <p class="text-muted small mb-0">
+                This is a secure area. Please re-enter your password to continue.
+            </p>
+        </div>
+
+        <form action="{{ route('password.confirm.store') }}" method="post">
+            @csrf
+
+            <div class="mb-3">
+                <label for="password" class="form-label">Password</label>
+                <div class="input-group">
+                    <span class="input-group-text"><i class="bi bi-lock text-secondary"></i></span>
+                    <input type="password"
+                           id="password"
+                           name="password"
+                           class="form-control @error('password') is-invalid @enderror"
+                           autocomplete="current-password"
+                           autofocus
+                           required>
+                </div>
+                @error('password')
+                    <div class="invalid-feedback d-block mt-1">{{ $message }}</div>
+                @enderror
+            </div>
+
+            <button class="btn btn-primary w-100" type="submit">
+                <i class="bi bi-shield-check me-2"></i> Confirm
+            </button>
+        </form>
+    </div>
+</div>
+
+<div class="text-center mt-4">
+    <small class="text-muted">&copy; {{ date('Y') }} YAAMS Virtual Airline Management</small>
+</div>
+
+@endsection

--- a/resources/views/settings/_password_confirm_modal.blade.php
+++ b/resources/views/settings/_password_confirm_modal.blade.php
@@ -1,0 +1,37 @@
+{{--
+    Reusable password-confirmation modal for a sensitive action.
+    Expects: $id, $action, $method (POST|DELETE), $title, $body, $submitLabel, $submitClass
+--}}
+<div class="modal fade" id="{{ $id }}" tabindex="-1" aria-labelledby="{{ $id }}Label" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <form action="{{ $action }}" method="post">
+                @csrf
+                @if ($method !== 'POST')
+                    @method($method)
+                @endif
+                <div class="modal-header">
+                    <h5 class="modal-title" id="{{ $id }}Label">{{ $title }}</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <p class="text-muted">{{ $body }}</p>
+                    <label for="{{ $id }}_password" class="form-label">Current password</label>
+                    <div class="input-group">
+                        <span class="input-group-text"><i class="bi bi-key text-secondary"></i></span>
+                        <input type="password"
+                               id="{{ $id }}_password"
+                               name="current_password"
+                               class="form-control"
+                               autocomplete="current-password"
+                               required>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn {{ $submitClass }}">{{ $submitLabel }}</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/resources/views/settings/security.blade.php
+++ b/resources/views/settings/security.blade.php
@@ -110,6 +110,9 @@
                     </div>
                 @endif
 
+                @error('current_password')
+                    <div class="alert alert-danger">{{ $message }}</div>
+                @enderror
                 @error('code')
                     <div class="alert alert-danger">{{ $message }}</div>
                 @enderror
@@ -119,12 +122,10 @@
                     <div class="d-flex align-items-center gap-2">
                         <span class="badge text-bg-secondary"><i class="bi bi-shield-slash me-1"></i> Disabled</span>
                     </div>
-                    <form action="{{ route('two-factor.enable') }}" method="post" class="mt-3">
-                        @csrf
-                        <button class="btn btn-primary" type="submit">
-                            <i class="bi bi-shield-plus me-2"></i> Enable two-factor authentication
-                        </button>
-                    </form>
+                    <button class="btn btn-primary mt-3" type="button"
+                            data-bs-toggle="modal" data-bs-target="#tfaEnableModal">
+                        <i class="bi bi-shield-plus me-2"></i> Enable two-factor authentication
+                    </button>
                 @elseif (is_null($tfaUser->two_factor_confirmed_at))
                     {{-- State: pending confirmation - show QR + confirm form --}}
                     <div class="alert alert-info">
@@ -138,7 +139,7 @@
                         Can't scan? Enter this setup key manually:
                         <code>{{ decrypt($tfaUser->two_factor_secret) }}</code>
                     </p>
-                    <form action="{{ route('two-factor.confirm') }}" method="post" class="mb-3">
+                    <form action="{{ route('settings.2fa.confirm') }}" method="post" class="mb-3">
                         @csrf
                         <label for="code" class="form-label">Authenticator code</label>
                         <div class="input-group" style="max-width: 320px;">
@@ -156,12 +157,8 @@
                             </button>
                         </div>
                     </form>
-                    <form action="{{ route('two-factor.disable') }}" method="post"
-                          onsubmit="return confirm('Cancel two-factor setup?')">
-                        @csrf
-                        @method('DELETE')
-                        <button class="btn btn-sm btn-outline-secondary" type="submit">Cancel setup</button>
-                    </form>
+                    <button class="btn btn-sm btn-outline-secondary" type="button"
+                            data-bs-toggle="modal" data-bs-target="#tfaCancelModal">Cancel setup</button>
                 @else
                     {{-- State: enabled --}}
                     <div class="d-flex align-items-center gap-2 mb-3">
@@ -169,35 +166,128 @@
                     </div>
 
                     <h6 class="fw-semibold mb-2">Recovery codes</h6>
-                    <p class="text-muted small">
-                        Store these in a safe place. Each code can be used once to sign in
-                        if you lose access to your authenticator app.
-                    </p>
-                    <div class="bg-body-secondary rounded p-3 mb-3 font-monospace small">
-                        @foreach ($tfaUser->recoveryCodes() as $recoveryCode)
-                            <div>{{ $recoveryCode }}</div>
-                        @endforeach
-                    </div>
 
-                    <div class="d-flex gap-2">
-                        <form action="{{ route('two-factor.regenerate-recovery-codes') }}" method="post">
-                            @csrf
-                            <button class="btn btn-outline-secondary btn-sm" type="submit">
+                    @if ($revealRecoveryCodes)
+                        {{-- One-time reveal: shown right after enabling/regenerating or a password-confirmed view --}}
+                        <div class="alert alert-warning">
+                            <i class="bi bi-exclamation-triangle-fill me-1"></i>
+                            Save these codes now - each can be used once to sign in if you lose your
+                            authenticator. They will not be shown again without confirming your password.
+                        </div>
+                        <div id="tfaRecoveryCodes" class="bg-body-secondary rounded p-3 mb-3 font-monospace small">
+                            @foreach ($tfaUser->recoveryCodes() as $recoveryCode)
+                                <div>{{ $recoveryCode }}</div>
+                            @endforeach
+                        </div>
+                        <div class="d-flex gap-2 flex-wrap mb-3">
+                            <button type="button" id="tfaCopyCodes" class="btn btn-outline-secondary btn-sm">
+                                <i class="bi bi-clipboard me-1"></i> Copy
+                            </button>
+                            <button type="button" id="tfaDownloadCodes" class="btn btn-outline-secondary btn-sm">
+                                <i class="bi bi-download me-1"></i> Download
+                            </button>
+                        </div>
+                        <a href="{{ route('settings.security') }}" class="btn btn-primary btn-sm">
+                            <i class="bi bi-check2-circle me-1"></i> I have saved my recovery codes
+                        </a>
+                        <script>
+                            (function () {
+                                const codes = @json($tfaUser->recoveryCodes());
+                                const text = codes.join('\n');
+                                const copyBtn = document.getElementById('tfaCopyCodes');
+                                const dlBtn = document.getElementById('tfaDownloadCodes');
+                                if (copyBtn) {
+                                    copyBtn.addEventListener('click', function () {
+                                        navigator.clipboard.writeText(text);
+                                    });
+                                }
+                                if (dlBtn) {
+                                    dlBtn.addEventListener('click', function () {
+                                        const blob = new Blob([text], { type: 'text/plain' });
+                                        const a = document.createElement('a');
+                                        a.href = URL.createObjectURL(blob);
+                                        a.download = 'yaams-recovery-codes.txt';
+                                        a.click();
+                                        URL.revokeObjectURL(a.href);
+                                    });
+                                }
+                            })();
+                        </script>
+                    @else
+                        {{-- Steady state: codes are hidden --}}
+                        <p class="text-muted small">
+                            Recovery codes let you sign in if you lose access to your authenticator app.
+                            They're kept hidden for security - confirm your password to view or regenerate them.
+                        </p>
+                        <div class="d-flex gap-2 flex-wrap">
+                            <button class="btn btn-outline-secondary btn-sm" type="button"
+                                    data-bs-toggle="modal" data-bs-target="#tfaViewCodesModal">
+                                <i class="bi bi-eye me-1"></i> View recovery codes
+                            </button>
+                            <button class="btn btn-outline-secondary btn-sm" type="button"
+                                    data-bs-toggle="modal" data-bs-target="#tfaRegenModal">
                                 <i class="bi bi-arrow-repeat me-1"></i> Regenerate recovery codes
                             </button>
-                        </form>
-                        <form action="{{ route('two-factor.disable') }}" method="post"
-                              onsubmit="return confirm('Disable two-factor authentication? Your account will only be protected by your password.')">
-                            @csrf
-                            @method('DELETE')
-                            <button class="btn btn-outline-danger btn-sm" type="submit">
+                            <button class="btn btn-outline-danger btn-sm" type="button"
+                                    data-bs-toggle="modal" data-bs-target="#tfaDisableModal">
                                 <i class="bi bi-shield-x me-1"></i> Disable
                             </button>
-                        </form>
-                    </div>
+                        </div>
+                    @endif
                 @endif
             </div>
         </div>
+
+        {{-- Password-confirmation modals for sensitive 2FA actions --}}
+        @if (! $tfaUser->two_factor_secret)
+            @include('settings._password_confirm_modal', [
+                'id' => 'tfaEnableModal',
+                'action' => route('settings.2fa.enable'),
+                'method' => 'POST',
+                'title' => 'Enable two-factor authentication',
+                'body' => 'Confirm your password to begin setting up two-factor authentication.',
+                'submitLabel' => 'Continue',
+                'submitClass' => 'btn-primary',
+            ])
+        @elseif (is_null($tfaUser->two_factor_confirmed_at))
+            @include('settings._password_confirm_modal', [
+                'id' => 'tfaCancelModal',
+                'action' => route('settings.2fa.disable'),
+                'method' => 'DELETE',
+                'title' => 'Cancel two-factor setup',
+                'body' => 'Confirm your password to cancel two-factor setup.',
+                'submitLabel' => 'Cancel setup',
+                'submitClass' => 'btn-danger',
+            ])
+        @elseif (! $revealRecoveryCodes)
+            @include('settings._password_confirm_modal', [
+                'id' => 'tfaViewCodesModal',
+                'action' => route('settings.2fa.recovery.show'),
+                'method' => 'POST',
+                'title' => 'View recovery codes',
+                'body' => 'Confirm your password to reveal your recovery codes.',
+                'submitLabel' => 'View codes',
+                'submitClass' => 'btn-primary',
+            ])
+            @include('settings._password_confirm_modal', [
+                'id' => 'tfaRegenModal',
+                'action' => route('settings.2fa.recovery.regenerate'),
+                'method' => 'POST',
+                'title' => 'Regenerate recovery codes',
+                'body' => 'Confirm your password to generate a new set of recovery codes. Your existing codes will stop working.',
+                'submitLabel' => 'Regenerate',
+                'submitClass' => 'btn-primary',
+            ])
+            @include('settings._password_confirm_modal', [
+                'id' => 'tfaDisableModal',
+                'action' => route('settings.2fa.disable'),
+                'method' => 'DELETE',
+                'title' => 'Disable two-factor authentication',
+                'body' => 'Confirm your password to disable two-factor authentication. Your account will only be protected by your password.',
+                'submitLabel' => 'Disable',
+                'submitClass' => 'btn-danger',
+            ])
+        @endif
 
         {{-- API tokens --}}
         <div class="card mt-4">

--- a/routes/web.php
+++ b/routes/web.php
@@ -78,6 +78,16 @@ Route::middleware(['auth'])->group(function () {
     Route::get('/settings', fn () => redirect()->route('settings.profile'))->name('settings');
     Route::get('/settings/profile', [SettingsController::class, 'profile'])->name('settings.profile');
     Route::get('/settings/security', [SettingsController::class, 'security'])->name('settings.security');
+
+    // Two-factor management — each mutation re-checks the account password in the
+    // controller (see SettingsController), so these do not rely on Fortify's own
+    // POST/DELETE 2FA routes.
+    Route::post('/settings/security/2fa/enable', [SettingsController::class, 'enableTwoFactor'])->name('settings.2fa.enable');
+    Route::post('/settings/security/2fa/confirm', [SettingsController::class, 'confirmTwoFactor'])->name('settings.2fa.confirm');
+    Route::post('/settings/security/2fa/recovery-codes', [SettingsController::class, 'regenerateRecoveryCodes'])->name('settings.2fa.recovery.regenerate');
+    Route::post('/settings/security/2fa/recovery-codes/show', [SettingsController::class, 'revealRecoveryCodes'])->name('settings.2fa.recovery.show');
+    Route::delete('/settings/security/2fa', [SettingsController::class, 'disableTwoFactor'])->name('settings.2fa.disable');
+
     Route::post('/settings/tokens', [SettingsController::class, 'storeToken'])->name('settings.tokens.store');
     Route::delete('/settings/tokens/{tokenId}', [SettingsController::class, 'destroyToken'])->name('settings.tokens.destroy');
     Route::get('/settings/notifications', [SettingsController::class, 'notifications'])->name('settings.notifications');

--- a/tests/Feature/TwoFactorAuthenticationTest.php
+++ b/tests/Feature/TwoFactorAuthenticationTest.php
@@ -47,22 +47,33 @@ class TwoFactorAuthenticationTest extends TestCase
     {
         $user = User::factory()->create();
 
-        $this->actingAs($user)->post(route('two-factor.enable'));
+        $this->actingAs($user)->post(route('settings.2fa.enable'), ['current_password' => 'password']);
 
         $user->refresh();
         $this->assertNotNull($user->two_factor_secret);
         $this->assertNull($user->two_factor_confirmed_at, '2FA must stay pending until confirmed');
     }
 
+    public function test_enabling_requires_the_current_password(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->post(route('settings.2fa.enable'), ['current_password' => 'wrong-password'])
+            ->assertSessionHasErrors('current_password');
+
+        $this->assertNull($user->fresh()->two_factor_secret);
+    }
+
     public function test_confirming_with_a_valid_code_enables_two_factor(): void
     {
         $user = User::factory()->create();
-        $this->actingAs($user)->post(route('two-factor.enable'));
+        $this->actingAs($user)->post(route('settings.2fa.enable'), ['current_password' => 'password']);
         $user->refresh();
 
         $code = $this->google2fa()->getCurrentOtp(decrypt($user->two_factor_secret));
 
-        $this->actingAs($user)->post(route('two-factor.confirm'), ['code' => $code]);
+        $this->actingAs($user)->post(route('settings.2fa.confirm'), ['code' => $code]);
 
         $this->assertNotNull($user->fresh()->two_factor_confirmed_at);
     }
@@ -149,7 +160,7 @@ class TwoFactorAuthenticationTest extends TestCase
     public function test_security_page_renders_the_qr_code_during_setup(): void
     {
         $user = User::factory()->create();
-        $this->actingAs($user)->post(route('two-factor.enable'));
+        $this->actingAs($user)->post(route('settings.2fa.enable'), ['current_password' => 'password']);
 
         $response = $this->actingAs($user)->get(route('settings.security'));
 
@@ -158,7 +169,7 @@ class TwoFactorAuthenticationTest extends TestCase
         $response->assertSee('Confirm');
     }
 
-    public function test_security_page_renders_recovery_codes_when_enabled(): void
+    public function test_recovery_codes_are_hidden_in_the_enabled_steady_state(): void
     {
         $user = User::factory()->create();
         $this->confirmTwoFactorFor($user);
@@ -167,8 +178,70 @@ class TwoFactorAuthenticationTest extends TestCase
 
         $response->assertOk();
         $response->assertSee('Recovery codes');
-        $response->assertSee('ABCDE-12345');
-        $response->assertSee('Regenerate recovery codes');
+        $response->assertSee('View recovery codes');
+        // The actual codes must NOT be rendered until re-authentication.
+        $response->assertDontSee('ABCDE-12345');
+    }
+
+    public function test_viewing_recovery_codes_requires_the_current_password(): void
+    {
+        $user = User::factory()->create();
+        $this->confirmTwoFactorFor($user);
+
+        // Wrong password: rejected, codes stay hidden.
+        $this->actingAs($user)
+            ->post(route('settings.2fa.recovery.show'), ['current_password' => 'wrong-password'])
+            ->assertSessionHasErrors('current_password');
+        $this->actingAs($user)->get(route('settings.security'))->assertDontSee('ABCDE-12345');
+
+        // Correct password: the codes are revealed once.
+        $this->actingAs($user)
+            ->followingRedirects()
+            ->post(route('settings.2fa.recovery.show'), ['current_password' => 'password'])
+            ->assertSee('ABCDE-12345');
+    }
+
+    public function test_recovery_codes_are_revealed_after_confirming(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user)->post(route('settings.2fa.enable'), ['current_password' => 'password']);
+        $user->refresh();
+
+        $code = $this->google2fa()->getCurrentOtp(decrypt($user->two_factor_secret));
+
+        $this->actingAs($user)
+            ->followingRedirects()
+            ->post(route('settings.2fa.confirm'), ['code' => $code])
+            ->assertSee('I have saved my recovery codes');
+    }
+
+    public function test_regenerating_recovery_codes_requires_the_current_password(): void
+    {
+        $user = User::factory()->create();
+        $this->confirmTwoFactorFor($user);
+
+        // Wrong password: rejected, existing codes unchanged.
+        $this->actingAs($user)
+            ->post(route('settings.2fa.recovery.regenerate'), ['current_password' => 'wrong-password'])
+            ->assertSessionHasErrors('current_password');
+        $this->assertContains('ABCDE-12345', $user->fresh()->recoveryCodes());
+
+        // Correct password: a new set is generated.
+        $this->actingAs($user)
+            ->post(route('settings.2fa.recovery.regenerate'), ['current_password' => 'password']);
+        $this->assertNotContains('ABCDE-12345', $user->fresh()->recoveryCodes());
+    }
+
+    public function test_disabling_requires_the_current_password(): void
+    {
+        $user = User::factory()->create();
+        $this->confirmTwoFactorFor($user);
+
+        $this->actingAs($user)
+            ->delete(route('settings.2fa.disable'), ['current_password' => 'wrong-password'])
+            ->assertSessionHasErrors('current_password');
+
+        $this->assertNotNull($user->fresh()->two_factor_secret, '2FA must remain enabled without the password');
     }
 
     public function test_disabling_clears_the_two_factor_columns(): void
@@ -176,7 +249,7 @@ class TwoFactorAuthenticationTest extends TestCase
         $user = User::factory()->create();
         $this->confirmTwoFactorFor($user);
 
-        $this->actingAs($user)->delete(route('two-factor.disable'));
+        $this->actingAs($user)->delete(route('settings.2fa.disable'), ['current_password' => 'password']);
 
         $user->refresh();
         $this->assertNull($user->two_factor_secret);


### PR DESCRIPTION
This fixes #99.

- Hide recovery codes after setup; show them once (after enable/regenerate or a password-confirmed reveal), never on every page load
- Require the account password for all sensitive 2FA actions (enable, disable, view codes, regenerate) via password-confirm modals
- Add copy/download and an "I have saved my recovery codes" acknowledgment on the one-time reveal
- Drive 2FA management through password-gated SettingsController routes delegating to Fortify's Action classes, avoiding the password.confirm middleware POST/DELETE redirect-drop
- Gate Fortify's built-in 2FA routes as defense-in-depth (confirmPassword => true) and add the confirm-password view
- Update and extend the 2FA test suite (16 tests)