### PR TITLE
Enhance role management for managers

### DIFF
--- a/app/Http/Controllers/AirlineController.php
+++ b/app/Http/Controllers/AirlineController.php
@@ -57,6 +57,7 @@ class AirlineController extends Controller
             'unit_is_lbs'          => $request->boolean('unit_is_lbs'),
             'active'               => true,
             'require_pirep_review' => true,
+            'owner_user_id'        => auth()->id(),
         ]);
 
         $airline->users()->attach(auth()->id(), ['role' => 'Manager']);

--- a/app/Http/Controllers/MemberController.php
+++ b/app/Http/Controllers/MemberController.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Airline;
+use App\Models\User;
+use App\Support\ActivityLevel;
+use Illuminate\Http\Request;
+
+class MemberController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware('auth');
+    }
+
+    public function index()
+    {
+        $airline = session('activeairline');
+
+        abort_unless($airline && auth()->user()->isManagerOf($airline), 403);
+
+        // Reload from DB — the session model is a snapshot
+        $airline = Airline::findOrFail($airline->id);
+
+        // Managers first, then Dispatchers, then Pilots; alphabetical within each.
+        // Sorted in PHP so it stays portable across MySQL/SQLite (tests).
+        $roleOrder = ['Manager' => 0, 'Dispatcher' => 1, 'Pilot' => 2];
+        $members = $airline->users()
+            ->orderBy('name')
+            ->get()
+            ->sortBy(fn ($member) => [$roleOrder[$member->pivot->role] ?? 99, $member->name])
+            ->values();
+
+        return view('manager.members', compact('airline', 'members'));
+    }
+
+    public function update(Request $request, User $member)
+    {
+        $airline = session('activeairline');
+
+        abort_unless($airline && auth()->user()->isManagerOf($airline), 403);
+        abort_unless($airline->isMember($member), 403);
+
+        $request->validate(['role' => 'required|in:Pilot,Dispatcher,Manager']);
+
+        if ($this->wouldRemoveLastManager($airline, $member, $request->role)) {
+            return back()->withErrors([
+                'role' => 'You cannot demote the last remaining Manager. Promote another member to Manager first.',
+            ]);
+        }
+
+        $airline->users()->updateExistingPivot($member->id, ['role' => $request->role]);
+
+        activity()
+            ->causedBy(auth()->user())
+            ->performedOn($airline)
+            ->withProperties(['level' => ActivityLevel::INFO])
+            ->event('airline_member_role_changed')
+            ->log($member->name . ' is now ' . $request->role . ' at ' . $airline->name);
+
+        return back()->with('success', $member->name . "'s role updated to " . $request->role . '.');
+    }
+
+    public function destroy(User $member)
+    {
+        $airline = session('activeairline');
+
+        abort_unless($airline && auth()->user()->isManagerOf($airline), 403);
+        abort_unless($airline->isMember($member), 403);
+
+        if ($this->wouldRemoveLastManager($airline, $member, null)) {
+            return back()->withErrors([
+                'member' => 'You cannot remove the last remaining Manager. Promote another member to Manager first.',
+            ]);
+        }
+
+        $airline->users()->detach($member->id);
+
+        activity()
+            ->causedBy(auth()->user())
+            ->performedOn($airline)
+            ->withProperties(['level' => ActivityLevel::INFO])
+            ->event('airline_member_removed')
+            ->log($member->name . ' was removed from ' . $airline->name);
+
+        return back()->with('success', $member->name . ' has been removed from the airline.');
+    }
+
+    /**
+     * Guard against leaving the airline with no Manager. A change only endangers the
+     * last Manager when it demotes (new role other than Manager) or removes ($newRole
+     * === null) a member who is currently a Manager and no other Manager remains.
+     */
+    private function wouldRemoveLastManager(Airline $airline, User $member, ?string $newRole): bool
+    {
+        if (! $member->isManagerOf($airline) || $newRole === 'Manager') {
+            return false;
+        }
+
+        $otherManagers = $airline->users()
+            ->wherePivot('role', 'Manager')
+            ->where('users.id', '!=', $member->id)
+            ->count();
+
+        return $otherManagers === 0;
+    }
+}

--- a/app/Http/Controllers/MemberController.php
+++ b/app/Http/Controllers/MemberController.php
@@ -6,6 +6,7 @@ use App\Models\Airline;
 use App\Models\User;
 use App\Support\ActivityLevel;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 
 class MemberController extends Controller
 {
@@ -23,13 +24,16 @@ class MemberController extends Controller
         // Reload from DB — the session model is a snapshot
         $airline = Airline::findOrFail($airline->id);
 
-        // Managers first, then Dispatchers, then Pilots; alphabetical within each.
+        // Owner first (represented by -1), then Managers (0), Dispatchers (1), Pilots (2); alphabetical within each.
         // Sorted in PHP so it stays portable across MySQL/SQLite (tests).
         $roleOrder = ['Manager' => 0, 'Dispatcher' => 1, 'Pilot' => 2];
         $members = $airline->users()
             ->orderBy('name')
             ->get()
-            ->sortBy(fn ($member) => [$roleOrder[$member->pivot->role] ?? 99, $member->name])
+            ->sortBy(fn ($member) => [
+                $member->id === $airline->owner_user_id ? -1 : ($roleOrder[$member->pivot->role] ?? 99),
+                $member->name
+            ])
             ->values();
 
         return view('manager.members', compact('airline', 'members'));
@@ -42,12 +46,19 @@ class MemberController extends Controller
         abort_unless($airline && auth()->user()->isManagerOf($airline), 403);
         abort_unless($airline->isMember($member), 403);
 
+        // Reload fresh to have accurate owner_user_id
+        $airline = Airline::findOrFail($airline->id);
+
+        $viewerIsOwner = auth()->user()->isOwnerOf($airline);
+        $targetIsOwner = $airline->owner_user_id === $member->id;
+
+        abort_if($targetIsOwner, 403);
+
         $request->validate(['role' => 'required|in:Pilot,Dispatcher,Manager']);
 
-        if ($this->wouldRemoveLastManager($airline, $member, $request->role)) {
-            return back()->withErrors([
-                'role' => 'You cannot demote the last remaining Manager. Promote another member to Manager first.',
-            ]);
+        if (! $viewerIsOwner) {
+            $isTargetManager = $member->hasAirlineRole($airline, 'Manager');
+            abort_if($isTargetManager || $request->role === 'Manager', 403);
         }
 
         $airline->users()->updateExistingPivot($member->id, ['role' => $request->role]);
@@ -69,10 +80,17 @@ class MemberController extends Controller
         abort_unless($airline && auth()->user()->isManagerOf($airline), 403);
         abort_unless($airline->isMember($member), 403);
 
-        if ($this->wouldRemoveLastManager($airline, $member, null)) {
-            return back()->withErrors([
-                'member' => 'You cannot remove the last remaining Manager. Promote another member to Manager first.',
-            ]);
+        // Reload fresh to have accurate owner_user_id
+        $airline = Airline::findOrFail($airline->id);
+
+        $viewerIsOwner = auth()->user()->isOwnerOf($airline);
+        $targetIsOwner = $airline->owner_user_id === $member->id;
+
+        abort_if($targetIsOwner, 403);
+
+        if (! $viewerIsOwner) {
+            $isTargetManager = $member->hasAirlineRole($airline, 'Manager');
+            abort_if($isTargetManager, 403);
         }
 
         $airline->users()->detach($member->id);
@@ -87,22 +105,37 @@ class MemberController extends Controller
         return back()->with('success', $member->name . ' has been removed from the airline.');
     }
 
-    /**
-     * Guard against leaving the airline with no Manager. A change only endangers the
-     * last Manager when it demotes (new role other than Manager) or removes ($newRole
-     * === null) a member who is currently a Manager and no other Manager remains.
-     */
-    private function wouldRemoveLastManager(Airline $airline, User $member, ?string $newRole): bool
+    public function transferOwnership(User $member)
     {
-        if (! $member->isManagerOf($airline) || $newRole === 'Manager') {
-            return false;
-        }
+        $airline = session('activeairline');
 
-        $otherManagers = $airline->users()
-            ->wherePivot('role', 'Manager')
-            ->where('users.id', '!=', $member->id)
-            ->count();
+        abort_unless($airline, 403);
+        $airline = Airline::findOrFail($airline->id);
 
-        return $otherManagers === 0;
+        abort_unless(auth()->user()->isOwnerOf($airline), 403);
+        abort_unless($airline->isMember($member), 403);
+        abort_if($member->id === auth()->id(), 422);
+
+        DB::transaction(function () use ($airline, $member) {
+            // Promote new owner to Manager role in memberships
+            $airline->users()->updateExistingPivot($member->id, ['role' => 'Manager']);
+            // Keep old owner as Manager in memberships
+            $airline->users()->updateExistingPivot(auth()->id(), ['role' => 'Manager']);
+            
+            $airline->owner_user_id = $member->id;
+            $airline->save();
+        });
+
+        // re-put the fresh airline into the session
+        session(['activeairline' => $airline]);
+
+        activity()
+            ->causedBy(auth()->user())
+            ->performedOn($airline)
+            ->withProperties(['level' => ActivityLevel::INFO])
+            ->event('airline_ownership_transferred')
+            ->log('Ownership of ' . $airline->name . ' transferred to ' . $member->name);
+
+        return back()->with('success', 'Ownership transferred to ' . $member->name . '. You are now a Manager.');
     }
 }

--- a/app/Http/Controllers/SetupController.php
+++ b/app/Http/Controllers/SetupController.php
@@ -121,6 +121,8 @@ class SetupController extends Controller
 
             $user->assignRole($superAdminRole);
             $airline->users()->attach($user, ['role' => 'Manager']);
+            $airline->owner_user_id = $user->id;
+            $airline->save();
 
             auth()->login($user);
             session(['activeairline' => $airline]);

--- a/app/Models/Airline.php
+++ b/app/Models/Airline.php
@@ -27,6 +27,7 @@ class Airline extends Model
         'active',
         'require_pirep_review',
         'location_continuity',
+        'owner_user_id',
     ];
 
     protected $casts = [
@@ -81,6 +82,16 @@ class Airline extends Model
     public function notams(): HasMany
     {
         return $this->hasMany(Notam::class);
+    }
+
+    public function owner(): \Illuminate\Database\Eloquent\Relations\BelongsTo
+    {
+        return $this->belongsTo(User::class, 'owner_user_id');
+    }
+
+    public function isOwnedBy(User $u): bool
+    {
+        return $this->owner_user_id !== null && $this->owner_user_id === $u->id;
     }
 
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -103,14 +103,19 @@ class User extends Authenticatable implements MustVerifyEmail
             ->exists();
     }
 
+    public function isOwnerOf(Airline $airline): bool
+    {
+        return $airline->owner_user_id === $this->id;
+    }
+
     public function isManagerOf(Airline $airline): bool
     {
-        return $this->hasAirlineRole($airline, 'Manager');
+        return $this->isOwnerOf($airline) || $this->hasAirlineRole($airline, 'Manager');
     }
 
     public function canReviewFlightsFor(Airline $airline): bool
     {
-        return $this->hasAirlineRole($airline, ['Dispatcher', 'Manager']);
+        return $this->isOwnerOf($airline) || $this->hasAirlineRole($airline, ['Dispatcher', 'Manager']);
     }
 
     public function countNewNotifications() {

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -148,7 +148,21 @@ class AppServiceProvider extends ServiceProvider
         });
 
         Gate::before(function ($user, $ability) {
-            return $user->hasRole('Super-Admin') ? true : null;
+            $activeAirline = session('activeairline');
+            if ($activeAirline) {
+                if ($ability === 'add aircraft' || $ability === 'edit aircraft') {
+                    return $user->isManagerOf($activeAirline);
+                }
+                if ($ability === 'review flight') {
+                    return $user->canReviewFlightsFor($activeAirline);
+                }
+            }
+
+            if ($user->hasRole('Super-Admin')) {
+                return true;
+            }
+
+            return null;
         });
     }
 }

--- a/database/migrations/2026_07_23_114200_add_owner_to_airlines_table.php
+++ b/database/migrations/2026_07_23_114200_add_owner_to_airlines_table.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('airlines', function (Blueprint $table) {
+            $table->foreignId('owner_user_id')->nullable()->after('id')->constrained('users')->nullOnDelete();
+        });
+
+        // Backfill
+        $airlines = DB::table('airlines')->get();
+        foreach ($airlines as $airline) {
+            $ownerUserId = DB::table('airline_memberships')
+                ->where('airline_id', $airline->id)
+                ->where('role', 'Manager')
+                ->orderBy('created_at')
+                ->orderBy('id')
+                ->value('user_id');
+
+            if (!$ownerUserId) {
+                $ownerUserId = DB::table('airline_memberships')
+                    ->where('airline_id', $airline->id)
+                    ->orderBy('created_at')
+                    ->orderBy('id')
+                    ->value('user_id');
+            }
+
+            if ($ownerUserId) {
+                DB::table('airlines')
+                    ->where('id', $airline->id)
+                    ->update(['owner_user_id' => $ownerUserId]);
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::table('airlines', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('owner_user_id');
+        });
+    }
+};

--- a/database/seeders/AirlineMembershipSeeder.php
+++ b/database/seeders/AirlineMembershipSeeder.php
@@ -44,5 +44,30 @@ class AirlineMembershipSeeder extends Seeder
                 }
             }
         }
+
+        // Set owners for all airlines
+        $airlines = DB::table('airlines')->get();
+        foreach ($airlines as $airline) {
+            $ownerUserId = DB::table('airline_memberships')
+                ->where('airline_id', $airline->id)
+                ->where('role', 'Manager')
+                ->orderBy('created_at')
+                ->orderBy('id')
+                ->value('user_id');
+
+            if (!$ownerUserId) {
+                $ownerUserId = DB::table('airline_memberships')
+                    ->where('airline_id', $airline->id)
+                    ->orderBy('created_at')
+                    ->orderBy('id')
+                    ->value('user_id');
+            }
+
+            if ($ownerUserId) {
+                DB::table('airlines')
+                    ->where('id', $airline->id)
+                    ->update(['owner_user_id' => $ownerUserId]);
+            }
+        }
     }
 }

--- a/resources/views/layouts/_navbar.blade.php
+++ b/resources/views/layouts/_navbar.blade.php
@@ -58,7 +58,7 @@
                     @endphp
                     @if($canReviewFlights || $isAirlineManager)
                         <li class="nav-item dropdown">
-                            <a class="nav-link dropdown-toggle {{ request()->routeIs('flightreviewindex', 'airline.settings', 'invitecodes.index', 'notams.index') ? 'active' : '' }}" href="#" id="navbarDropdownManagement" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                            <a class="nav-link dropdown-toggle {{ request()->routeIs('flightreviewindex', 'airline.settings', 'members.index', 'invitecodes.index', 'notams.index') ? 'active' : '' }}" href="#" id="navbarDropdownManagement" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                                 <i class="bi bi-briefcase"></i> Management
                             </a>
                             <ul class="dropdown-menu shadow-sm border-0" aria-labelledby="navbarDropdownManagement">
@@ -70,6 +70,7 @@
                                 @endif
                                 @if($isAirlineManager)
                                     <li><a class="dropdown-item {{ request()->routeIs('airline.settings') ? 'active' : '' }}" href="{{ route('airline.settings') }}"><i class="bi bi-sliders me-2 text-secondary"></i> Operations</a></li>
+                                    <li><a class="dropdown-item {{ request()->routeIs('members.index') ? 'active' : '' }}" href="{{ route('members.index') }}"><i class="bi bi-people me-2 text-secondary"></i> Members</a></li>
                                     <li><a class="dropdown-item {{ request()->routeIs('invitecodes.index') ? 'active' : '' }}" href="{{ route('invitecodes.index') }}"><i class="bi bi-ticket-perforated me-2 text-secondary"></i> Invite codes</a></li>
                                     <li><a class="dropdown-item {{ request()->routeIs('notams.index') ? 'active' : '' }}" href="{{ route('notams.index') }}"><i class="bi bi-megaphone me-2 text-secondary"></i> Announcements</a></li>
                                 @endif

--- a/resources/views/manager/_sidebar.blade.php
+++ b/resources/views/manager/_sidebar.blade.php
@@ -1,5 +1,5 @@
 {{-- Airline management sections sidebar. Pass $active
-     ('operations' | 'invitecodes' | 'announcements') to highlight the current section. --}}
+     ('operations' | 'members' | 'invitecodes' | 'announcements') to highlight the current section. --}}
 @php($active = $active ?? 'operations')
 <div class="col-12 col-lg-3">
     <div class="card">
@@ -7,6 +7,10 @@
             <a href="{{ route('airline.settings') }}"
                class="list-group-item list-group-item-action {{ $active === 'operations' ? 'active' : '' }}">
                 <i class="bi bi-sliders me-2"></i> Operations
+            </a>
+            <a href="{{ route('members.index') }}"
+               class="list-group-item list-group-item-action {{ $active === 'members' ? 'active' : '' }}">
+                <i class="bi bi-people me-2"></i> Members
             </a>
             <a href="{{ route('invitecodes.index') }}"
                class="list-group-item list-group-item-action {{ $active === 'invitecodes' ? 'active' : '' }}">

--- a/resources/views/manager/members.blade.php
+++ b/resources/views/manager/members.blade.php
@@ -4,6 +4,10 @@
 
 @section('content')
 
+@php
+    $viewerIsOwner = auth()->user()->isOwnerOf($airline);
+@endphp
+
 <div class="d-flex justify-content-between align-items-center mb-4">
     <div>
         <h1 class="h3 mb-1"><i class="bi bi-speedometer2 me-2"></i> Airline Management</h1>
@@ -46,35 +50,69 @@
                     </thead>
                     <tbody>
                         @forelse($members as $member)
+                            @php
+                                $rowIsOwner = $airline->owner_user_id === $member->id;
+                                $rowIsManager = $member->pivot->role === 'Manager';
+                            @endphp
                             <tr>
                                 <td>
                                     <span class="fw-semibold">{{ $member->name }}</span>
                                     @if($member->id === auth()->id())
                                         <span class="badge bg-primary-subtle text-primary border border-primary-subtle ms-1">You</span>
                                     @endif
+                                    @if($rowIsOwner)
+                                        <span class="badge bg-warning-subtle text-warning border border-warning-subtle ms-1"><i class="bi bi-star-fill me-1"></i>Owner</span>
+                                    @endif
                                 </td>
                                 <td>
-                                    <form action="{{ route('members.update', $member) }}" method="POST" class="d-flex gap-2 align-items-center">
-                                        @csrf
-                                        @method('PUT')
-                                        <select name="role" class="form-select form-select-sm" style="width:auto"
-                                                onchange="this.form.querySelector('button').classList.remove('d-none')">
-                                            <option value="Pilot" @selected($member->pivot->role === 'Pilot')>Pilot</option>
-                                            <option value="Dispatcher" @selected($member->pivot->role === 'Dispatcher')>Dispatcher</option>
-                                            <option value="Manager" @selected($member->pivot->role === 'Manager')>Manager</option>
-                                        </select>
-                                        <button type="submit" class="btn btn-sm btn-primary d-none">Save</button>
-                                    </form>
+                                    @if($rowIsOwner)
+                                        <span class="text-muted">Owner</span>
+                                    @else
+                                        @if($rowIsManager && ! $viewerIsOwner)
+                                            <span class="badge bg-secondary-subtle text-secondary border border-secondary-subtle">Manager</span>
+                                        @else
+                                            <form action="{{ route('members.update', $member) }}" method="POST" class="d-flex gap-2 align-items-center">
+                                                @csrf
+                                                @method('PUT')
+                                                <select name="role" class="form-select form-select-sm" style="width:auto"
+                                                        onchange="this.form.querySelector('button').classList.remove('d-none')">
+                                                    <option value="Pilot" @selected($member->pivot->role === 'Pilot')>Pilot</option>
+                                                    <option value="Dispatcher" @selected($member->pivot->role === 'Dispatcher')>Dispatcher</option>
+                                                    @if($viewerIsOwner)
+                                                        <option value="Manager" @selected($member->pivot->role === 'Manager')>Manager</option>
+                                                    @endif
+                                                </select>
+                                                <button type="submit" class="btn btn-sm btn-primary d-none">Save</button>
+                                            </form>
+                                        @endif
+                                    @endif
                                 </td>
                                 <td class="text-end">
-                                    <form action="{{ route('members.destroy', $member) }}" method="POST"
-                                          onsubmit="return confirm('Remove {{ $member->name }} from the airline?')">
-                                        @csrf
-                                        @method('DELETE')
-                                        <button type="submit" class="btn btn-sm btn-outline-danger">
-                                            <i class="bi bi-person-x"></i> Remove
-                                        </button>
-                                    </form>
+                                    @if(! $rowIsOwner)
+                                        <div class="d-flex justify-content-end gap-2">
+                                            @if($viewerIsOwner)
+                                                <form action="{{ route('members.transfer', $member) }}" method="POST"
+                                                      onsubmit="return confirm('Are you sure you want to transfer ownership of this airline to {{ $member->name }}? You will step down to a Manager.')">
+                                                    @csrf
+                                                    @method('PUT')
+                                                    <button type="submit" class="btn btn-sm btn-outline-warning">
+                                                        <i class="bi bi-gift-fill me-1"></i> Make Owner
+                                                    </button>
+                                                </form>
+                                            @endif
+
+                                            @if($viewerIsOwner || ! $rowIsManager)
+                                                <form action="{{ route('members.destroy', $member) }}" method="POST"
+                                                      onsubmit="return confirm('Remove {{ $member->name }} from the airline?')">
+                                                    @csrf
+                                                    @method('DELETE')
+                                                    <button type="submit" class="btn btn-sm btn-outline-danger">
+                                                        <i class="bi bi-person-x"></i> Remove
+                                                    </button>
+                                                </form>
+                                            @endif
+                                        </div>
+                                    @endif
                                 </td>
                             </tr>
                         @empty

--- a/resources/views/manager/members.blade.php
+++ b/resources/views/manager/members.blade.php
@@ -1,0 +1,92 @@
+@extends('layouts.app')
+
+@section('title', 'Members')
+
+@section('content')
+
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <div>
+        <h1 class="h3 mb-1"><i class="bi bi-speedometer2 me-2"></i> Airline Management</h1>
+        <p class="text-muted mb-0">{{ $airline->name }} ({{ $airline->icao_callsign }})</p>
+    </div>
+</div>
+
+<div class="row g-4">
+    {{-- Sidebar: airline settings sections --}}
+    @include('manager._sidebar', ['active' => 'members'])
+
+    {{-- Main: members --}}
+    <div class="col-12 col-lg-9">
+        @if(session('success'))
+            <div class="alert alert-success alert-dismissible fade show" role="alert">
+                <i class="bi bi-check-circle me-2"></i>{{ session('success') }}
+                <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+            </div>
+        @endif
+
+        @if($errors->any())
+            <div class="alert alert-danger alert-dismissible fade show" role="alert">
+                <i class="bi bi-exclamation-triangle-fill me-2"></i>{{ $errors->first() }}
+                <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+            </div>
+        @endif
+
+        <div class="card">
+            <div class="card-header">
+                <span>Members</span>
+            </div>
+            <div class="table-responsive">
+                <table class="table table-hover align-middle mb-0">
+                    <thead class="table-light">
+                        <tr>
+                            <th>Name</th>
+                            <th>Role</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse($members as $member)
+                            <tr>
+                                <td>
+                                    <span class="fw-semibold">{{ $member->name }}</span>
+                                    @if($member->id === auth()->id())
+                                        <span class="badge bg-primary-subtle text-primary border border-primary-subtle ms-1">You</span>
+                                    @endif
+                                </td>
+                                <td>
+                                    <form action="{{ route('members.update', $member) }}" method="POST" class="d-flex gap-2 align-items-center">
+                                        @csrf
+                                        @method('PUT')
+                                        <select name="role" class="form-select form-select-sm" style="width:auto"
+                                                onchange="this.form.querySelector('button').classList.remove('d-none')">
+                                            <option value="Pilot" @selected($member->pivot->role === 'Pilot')>Pilot</option>
+                                            <option value="Dispatcher" @selected($member->pivot->role === 'Dispatcher')>Dispatcher</option>
+                                            <option value="Manager" @selected($member->pivot->role === 'Manager')>Manager</option>
+                                        </select>
+                                        <button type="submit" class="btn btn-sm btn-primary d-none">Save</button>
+                                    </form>
+                                </td>
+                                <td class="text-end">
+                                    <form action="{{ route('members.destroy', $member) }}" method="POST"
+                                          onsubmit="return confirm('Remove {{ $member->name }} from the airline?')">
+                                        @csrf
+                                        @method('DELETE')
+                                        <button type="submit" class="btn btn-sm btn-outline-danger">
+                                            <i class="bi bi-person-x"></i> Remove
+                                        </button>
+                                    </form>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="3" class="text-center text-muted py-4">No members yet.</td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -118,6 +118,7 @@ Route::middleware(['auth'])->group(function () {
         Route::get('/airline/members', [MemberController::class, 'index'])->name('members.index');
         Route::put('/airline/members/{member}', [MemberController::class, 'update'])->name('members.update');
         Route::delete('/airline/members/{member}', [MemberController::class, 'destroy'])->name('members.destroy');
+        Route::put('/airline/members/{member}/transfer-ownership', [MemberController::class, 'transferOwnership'])->name('members.transfer');
 
         // Announcements / NOTAMs (manager check enforced in controller)
         Route::get('/airline/announcements', [NotamController::class, 'index'])->name('notams.index');

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,6 +12,7 @@ use App\Http\Controllers\SetupController;
 use App\Http\Controllers\HomeController;
 use App\Http\Controllers\PortalController;
 use App\Http\Controllers\InviteCodeController;
+use App\Http\Controllers\MemberController;
 use App\Http\Controllers\NotamController;
 use App\Http\Controllers\AirlineController;
 use App\Http\Controllers\SettingsController;
@@ -112,6 +113,11 @@ Route::middleware(['auth'])->group(function () {
         // Airline settings (manager check enforced in controller)
         Route::get('/airline/settings', [AirlineController::class, 'settings'])->name('airline.settings');
         Route::put('/airline/settings', [AirlineController::class, 'updateSettings'])->name('airline.settings.update');
+
+        // Member management (manager check enforced in controller)
+        Route::get('/airline/members', [MemberController::class, 'index'])->name('members.index');
+        Route::put('/airline/members/{member}', [MemberController::class, 'update'])->name('members.update');
+        Route::delete('/airline/members/{member}', [MemberController::class, 'destroy'])->name('members.destroy');
 
         // Announcements / NOTAMs (manager check enforced in controller)
         Route::get('/airline/announcements', [NotamController::class, 'index'])->name('notams.index');

--- a/tests/Concerns/SeedsDomain.php
+++ b/tests/Concerns/SeedsDomain.php
@@ -68,4 +68,18 @@ trait SeedsDomain
 
         return $user;
     }
+
+    /**
+     * Create a user, attach them to the airline as a Manager, and set them
+     * as the owner of the airline.
+     */
+    protected function ownerOf(Airline $airline): User
+    {
+        $user = User::factory()->create();
+        $user->airlines()->attach($airline->id, ['role' => 'Manager']);
+        $airline->owner_user_id = $user->id;
+        $airline->save();
+
+        return $user;
+    }
 }

--- a/tests/Feature/MemberManagementTest.php
+++ b/tests/Feature/MemberManagementTest.php
@@ -3,14 +3,11 @@
 namespace Tests\Feature;
 
 use App\Models\Airline;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\Concerns\SeedsDomain;
 use Tests\TestCase;
 
-/**
- * Airline Managers can change other members' per-airline roles and remove members,
- * with a guard that the airline is never left without a Manager.
- */
 class MemberManagementTest extends TestCase
 {
     use RefreshDatabase, SeedsDomain;
@@ -26,11 +23,67 @@ class MemberManagementTest extends TestCase
         return $user->fresh()->airlines()->find($airline->id)?->pivot->role;
     }
 
-    public function test_manager_can_change_a_members_role(): void
+    public function test_founding_sets_owner_and_manager_role(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('Super-Admin');
+
+        $this->actingAs($user)
+            ->post(route('airline.found.store'), [
+                'airline_name'     => 'Test Airline',
+                'airline_prefix'   => 'TA',
+                'airline_icao'     => 'TAL',
+                'airline_callsign' => 'TESTAIR',
+                'airline_hub'      => 'EDDF',
+                'airline_country'  => 'DE',
+                'airline_desc'     => 'A test airline',
+                'airline_website'  => 'https://example.com',
+                'airline_founded'  => '2026-07-23',
+                'unit_is_lbs'      => 0,
+            ])
+            ->assertRedirect();
+
+        $airline = Airline::where('icao_callsign', 'TAL')->first();
+        $this->assertNotNull($airline);
+        $this->assertSame($user->id, $airline->owner_user_id);
+        $this->assertTrue($user->isManagerOf($airline));
+        $this->assertSame('Manager', $this->roleOf($user, $airline));
+    }
+
+    public function test_owner_can_promote_pilot_to_manager(): void
     {
         $airline = Airline::factory()->create();
+        $owner = $this->ownerOf($airline);
+        $pilot = $this->memberOf($airline, 'Pilot');
+
+        $this->actingAs($owner)
+            ->withSession(['activeairline' => $airline])
+            ->put(route('members.update', $pilot), ['role' => 'Manager'])
+            ->assertRedirect();
+
+        $this->assertSame('Manager', $this->roleOf($pilot, $airline));
+    }
+
+    public function test_owner_can_demote_manager_to_pilot(): void
+    {
+        $airline = Airline::factory()->create();
+        $owner = $this->ownerOf($airline);
         $manager = $this->memberOf($airline, 'Manager');
-        $pilot   = $this->memberOf($airline, 'Pilot');
+
+        $this->actingAs($owner)
+            ->withSession(['activeairline' => $airline])
+            ->put(route('members.update', $manager), ['role' => 'Pilot'])
+            ->assertRedirect();
+
+        $this->assertSame('Pilot', $this->roleOf($manager, $airline));
+    }
+
+    public function test_non_owner_manager_can_change_pilot_to_dispatcher(): void
+    {
+        $airline = Airline::factory()->create();
+        $owner = $this->ownerOf($airline);
+        $manager = $this->memberOf($airline, 'Manager');
+        $pilot = $this->memberOf($airline, 'Pilot');
 
         $this->actingAs($manager)
             ->withSession(['activeairline' => $airline])
@@ -40,64 +93,136 @@ class MemberManagementTest extends TestCase
         $this->assertSame('Dispatcher', $this->roleOf($pilot, $airline));
     }
 
-    public function test_manager_can_remove_a_member(): void
+    public function test_non_owner_manager_cannot_promote_to_manager(): void
     {
         $airline = Airline::factory()->create();
+        $owner = $this->ownerOf($airline);
         $manager = $this->memberOf($airline, 'Manager');
-        $pilot   = $this->memberOf($airline, 'Pilot');
+        $pilot = $this->memberOf($airline, 'Pilot');
 
         $this->actingAs($manager)
             ->withSession(['activeairline' => $airline])
-            ->delete(route('members.destroy', $pilot))
+            ->put(route('members.update', $pilot), ['role' => 'Manager'])
+            ->assertForbidden();
+
+        $this->assertSame('Pilot', $this->roleOf($pilot, $airline));
+    }
+
+    public function test_non_owner_manager_cannot_demote_manager(): void
+    {
+        $airline = Airline::factory()->create();
+        $owner = $this->ownerOf($airline);
+        $manager = $this->memberOf($airline, 'Manager');
+        $otherManager = $this->memberOf($airline, 'Manager');
+
+        $this->actingAs($manager)
+            ->withSession(['activeairline' => $airline])
+            ->put(route('members.update', $otherManager), ['role' => 'Pilot'])
+            ->assertForbidden();
+
+        $this->assertSame('Manager', $this->roleOf($otherManager, $airline));
+    }
+
+    public function test_non_owner_manager_cannot_remove_manager(): void
+    {
+        $airline = Airline::factory()->create();
+        $owner = $this->ownerOf($airline);
+        $manager = $this->memberOf($airline, 'Manager');
+        $otherManager = $this->memberOf($airline, 'Manager');
+
+        $this->actingAs($manager)
+            ->withSession(['activeairline' => $airline])
+            ->delete(route('members.destroy', $otherManager))
+            ->assertForbidden();
+
+        $this->assertTrue($airline->isMember($otherManager->fresh()));
+    }
+
+    public function test_nobody_can_update_or_remove_owner(): void
+    {
+        $airline = Airline::factory()->create();
+        $owner = $this->ownerOf($airline);
+        $manager = $this->memberOf($airline, 'Manager');
+
+        // Manager trying to update owner
+        $this->actingAs($manager)
+            ->withSession(['activeairline' => $airline])
+            ->put(route('members.update', $owner), ['role' => 'Pilot'])
+            ->assertForbidden();
+
+        // Manager trying to remove owner
+        $this->actingAs($manager)
+            ->withSession(['activeairline' => $airline])
+            ->delete(route('members.destroy', $owner))
+            ->assertForbidden();
+
+        // Owner trying to demote self
+        $this->actingAs($owner)
+            ->withSession(['activeairline' => $airline])
+            ->put(route('members.update', $owner), ['role' => 'Pilot'])
+            ->assertForbidden();
+
+        // Owner trying to remove self
+        $this->actingAs($owner)
+            ->withSession(['activeairline' => $airline])
+            ->delete(route('members.destroy', $owner))
+            ->assertForbidden();
+
+        $this->assertSame('Manager', $this->roleOf($owner, $airline));
+        $this->assertTrue($airline->isMember($owner->fresh()));
+    }
+
+    public function test_owner_can_transfer_ownership(): void
+    {
+        $airline = Airline::factory()->create();
+        $owner = $this->ownerOf($airline);
+        $member = $this->memberOf($airline, 'Pilot');
+
+        $this->actingAs($owner)
+            ->withSession(['activeairline' => $airline])
+            ->put(route('members.transfer', $member))
             ->assertRedirect();
 
-        $this->assertFalse($airline->isMember($pilot->fresh()));
+        $airline = $airline->fresh();
+        $this->assertSame($member->id, $airline->owner_user_id);
+        $this->assertSame('Manager', $this->roleOf($owner, $airline));
+        $this->assertSame('Manager', $this->roleOf($member, $airline));
+        $this->assertSame($airline->owner_user_id, session('activeairline')->owner_user_id);
     }
 
-    public function test_last_manager_cannot_be_demoted(): void
+    public function test_non_owner_cannot_transfer_ownership(): void
     {
         $airline = Airline::factory()->create();
+        $owner = $this->ownerOf($airline);
         $manager = $this->memberOf($airline, 'Manager');
+        $pilot = $this->memberOf($airline, 'Pilot');
 
         $this->actingAs($manager)
             ->withSession(['activeairline' => $airline])
-            ->put(route('members.update', $manager), ['role' => 'Pilot'])
-            ->assertSessionHasErrors('role');
+            ->put(route('members.transfer', $pilot))
+            ->assertForbidden();
 
-        $this->assertSame('Manager', $this->roleOf($manager, $airline));
+        $this->assertSame($owner->id, $airline->fresh()->owner_user_id);
     }
 
-    public function test_last_manager_cannot_be_removed(): void
+    public function test_owner_cannot_transfer_to_self(): void
     {
         $airline = Airline::factory()->create();
-        $manager = $this->memberOf($airline, 'Manager');
+        $owner = $this->ownerOf($airline);
 
-        $this->actingAs($manager)
+        $this->actingAs($owner)
             ->withSession(['activeairline' => $airline])
-            ->delete(route('members.destroy', $manager))
-            ->assertSessionHasErrors('member');
+            ->put(route('members.transfer', $owner))
+            ->assertStatus(422);
 
-        $this->assertTrue($airline->isMember($manager->fresh()));
-    }
-
-    public function test_manager_can_be_demoted_when_another_manager_exists(): void
-    {
-        $airline = Airline::factory()->create();
-        $manager = $this->memberOf($airline, 'Manager');
-        $other   = $this->memberOf($airline, 'Manager');
-
-        $this->actingAs($other)
-            ->withSession(['activeairline' => $airline])
-            ->put(route('members.update', $manager), ['role' => 'Pilot'])
-            ->assertRedirect();
-
-        $this->assertSame('Pilot', $this->roleOf($manager, $airline));
+        $this->assertSame($owner->id, $airline->fresh()->owner_user_id);
     }
 
     public function test_non_manager_cannot_access_members(): void
     {
         $airline = Airline::factory()->create();
-        $pilot   = $this->memberOf($airline, 'Pilot');
+        $owner = $this->ownerOf($airline);
+        $pilot = $this->memberOf($airline, 'Pilot');
 
         $this->actingAs($pilot)
             ->withSession(['activeairline' => $airline])
@@ -108,6 +233,7 @@ class MemberManagementTest extends TestCase
     public function test_manager_cannot_update_member_of_another_airline(): void
     {
         $airline = Airline::factory()->create();
+        $owner = $this->ownerOf($airline);
         $manager = $this->memberOf($airline, 'Manager');
 
         $otherAirline = Airline::factory()->create();
@@ -117,5 +243,20 @@ class MemberManagementTest extends TestCase
             ->withSession(['activeairline' => $airline])
             ->put(route('members.update', $outsider), ['role' => 'Manager'])
             ->assertForbidden();
+    }
+
+    public function test_manager_can_remove_pilot(): void
+    {
+        $airline = Airline::factory()->create();
+        $owner = $this->ownerOf($airline);
+        $manager = $this->memberOf($airline, 'Manager');
+        $pilot = $this->memberOf($airline, 'Pilot');
+
+        $this->actingAs($manager)
+            ->withSession(['activeairline' => $airline])
+            ->delete(route('members.destroy', $pilot))
+            ->assertRedirect();
+
+        $this->assertFalse($airline->isMember($pilot->fresh()));
     }
 }

--- a/tests/Feature/MemberManagementTest.php
+++ b/tests/Feature/MemberManagementTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Airline;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Concerns\SeedsDomain;
+use Tests\TestCase;
+
+/**
+ * Airline Managers can change other members' per-airline roles and remove members,
+ * with a guard that the airline is never left without a Manager.
+ */
+class MemberManagementTest extends TestCase
+{
+    use RefreshDatabase, SeedsDomain;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seedReferenceData();
+    }
+
+    private function roleOf($user, Airline $airline): ?string
+    {
+        return $user->fresh()->airlines()->find($airline->id)?->pivot->role;
+    }
+
+    public function test_manager_can_change_a_members_role(): void
+    {
+        $airline = Airline::factory()->create();
+        $manager = $this->memberOf($airline, 'Manager');
+        $pilot   = $this->memberOf($airline, 'Pilot');
+
+        $this->actingAs($manager)
+            ->withSession(['activeairline' => $airline])
+            ->put(route('members.update', $pilot), ['role' => 'Dispatcher'])
+            ->assertRedirect();
+
+        $this->assertSame('Dispatcher', $this->roleOf($pilot, $airline));
+    }
+
+    public function test_manager_can_remove_a_member(): void
+    {
+        $airline = Airline::factory()->create();
+        $manager = $this->memberOf($airline, 'Manager');
+        $pilot   = $this->memberOf($airline, 'Pilot');
+
+        $this->actingAs($manager)
+            ->withSession(['activeairline' => $airline])
+            ->delete(route('members.destroy', $pilot))
+            ->assertRedirect();
+
+        $this->assertFalse($airline->isMember($pilot->fresh()));
+    }
+
+    public function test_last_manager_cannot_be_demoted(): void
+    {
+        $airline = Airline::factory()->create();
+        $manager = $this->memberOf($airline, 'Manager');
+
+        $this->actingAs($manager)
+            ->withSession(['activeairline' => $airline])
+            ->put(route('members.update', $manager), ['role' => 'Pilot'])
+            ->assertSessionHasErrors('role');
+
+        $this->assertSame('Manager', $this->roleOf($manager, $airline));
+    }
+
+    public function test_last_manager_cannot_be_removed(): void
+    {
+        $airline = Airline::factory()->create();
+        $manager = $this->memberOf($airline, 'Manager');
+
+        $this->actingAs($manager)
+            ->withSession(['activeairline' => $airline])
+            ->delete(route('members.destroy', $manager))
+            ->assertSessionHasErrors('member');
+
+        $this->assertTrue($airline->isMember($manager->fresh()));
+    }
+
+    public function test_manager_can_be_demoted_when_another_manager_exists(): void
+    {
+        $airline = Airline::factory()->create();
+        $manager = $this->memberOf($airline, 'Manager');
+        $other   = $this->memberOf($airline, 'Manager');
+
+        $this->actingAs($other)
+            ->withSession(['activeairline' => $airline])
+            ->put(route('members.update', $manager), ['role' => 'Pilot'])
+            ->assertRedirect();
+
+        $this->assertSame('Pilot', $this->roleOf($manager, $airline));
+    }
+
+    public function test_non_manager_cannot_access_members(): void
+    {
+        $airline = Airline::factory()->create();
+        $pilot   = $this->memberOf($airline, 'Pilot');
+
+        $this->actingAs($pilot)
+            ->withSession(['activeairline' => $airline])
+            ->get(route('members.index'))
+            ->assertForbidden();
+    }
+
+    public function test_manager_cannot_update_member_of_another_airline(): void
+    {
+        $airline = Airline::factory()->create();
+        $manager = $this->memberOf($airline, 'Manager');
+
+        $otherAirline = Airline::factory()->create();
+        $outsider     = $this->memberOf($otherAirline, 'Pilot');
+
+        $this->actingAs($manager)
+            ->withSession(['activeairline' => $airline])
+            ->put(route('members.update', $outsider), ['role' => 'Manager'])
+            ->assertForbidden();
+    }
+}

--- a/tests/Feature/MemberManagementTest.php
+++ b/tests/Feature/MemberManagementTest.php
@@ -259,4 +259,40 @@ class MemberManagementTest extends TestCase
 
         $this->assertFalse($airline->isMember($pilot->fresh()));
     }
+
+    public function test_ownership_transfer_preserves_add_aircraft_permission_for_both(): void
+    {
+        $airline = Airline::factory()->create();
+        $owner = $this->ownerOf($airline);
+        $member = $this->memberOf($airline, 'Pilot');
+
+        // Transfer ownership
+        $this->actingAs($owner)
+            ->withSession(['activeairline' => $airline])
+            ->put(route('members.transfer', $member))
+            ->assertRedirect();
+
+        // New owner (was Pilot) can add aircraft
+        $this->actingAs($member->fresh())
+            ->withSession(['activeairline' => $airline])
+            ->get(route('createaircraft'))
+            ->assertOk();
+
+        // Old owner (now Manager) can also still add aircraft
+        $this->actingAs($owner->fresh())
+            ->withSession(['activeairline' => $airline])
+            ->get(route('createaircraft'))
+            ->assertOk();
+    }
+
+    public function test_pilot_does_not_have_add_aircraft_permission_on_active_airline(): void
+    {
+        $airline = Airline::factory()->create();
+        $pilot = $this->memberOf($airline, 'Pilot');
+
+        $this->actingAs($pilot)
+            ->withSession(['activeairline' => $airline])
+            ->get(route('createaircraft'))
+            ->assertForbidden();
+    }
 }


### PR DESCRIPTION
This adds a few things:

* Managers can now see the airline members and change their role.
* Every founder of an airline becomes an "Owner". This has the essentially the same permissions as a manager, but an Owner is unable to be downgraded to a Dispatcher/Pilot. Only a "Transfer Ownership" does this. This is to protect an evil pilot, who becomes a manager and downgrades all the others.
* Implement tests for this
